### PR TITLE
Major update

### DIFF
--- a/assets/css/dashicons-picker.css
+++ b/assets/css/dashicons-picker.css
@@ -1,0 +1,73 @@
+.talkino-dashicon-picker-container {
+	position: absolute;
+	width: 220px;
+	height: 252px;
+	font-size: 14px;
+	background-color: #fff;
+	-webkit-box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+	overflow: hidden;
+	padding: 5px;
+	box-sizing: border-box;
+}
+
+.talkino-dashicon-picker-container ul {
+	margin: 0;
+	padding: 0;
+	margin-bottom: 10px;
+}
+
+.talkino-dashicon-picker-container ul .dashicons {
+	width: 20px;
+	height: 20px;
+	font-size: 20px;
+}
+
+.talkino-dashicon-picker-container ul li {
+	display: inline-block;
+	margin: 5px;
+}
+
+.talkino-dashicon-picker-container ul li a {
+	display: block;
+	text-decoration: none;
+	color: #373737;
+	padding: 5px 5px;
+	border: 1px solid #dfdfdf;
+}
+
+.talkino-dashicon-picker-container ul li a:hover {
+	border-color: #999;
+	background: #efefef;
+}
+
+.talkino-dashicon-picker-control {
+	height: 32px;
+}
+
+.talkino-dashicon-picker-control a {
+	padding: 5px;
+	text-decoration: none;
+	line-height: 32px;
+	width: 25px;
+}
+
+.talkino-dashicon-picker-control a span {
+	display: inline;
+	vertical-align: middle;
+}
+
+.talkino-dashicon-picker-control input {
+	font-size: 12px;
+	width: 140px;
+}
+
+#talkino-icon-container {
+    background: white;
+    text-align: center;
+    border-style: dashed;
+    width: 50px;
+    padding: 10px 0 10px 0;
+    margin-bottom: 10px;
+    display: block;
+}

--- a/assets/css/talkino-admin.css
+++ b/assets/css/talkino-admin.css
@@ -87,6 +87,14 @@
     width: 30%;
 }
 
+.show_only_on_mobile_view {
+    padding-top: 10px;
+}
+  
+#talkino_phone_show_only_on_mobile_status {
+    margin-top: 10px;
+}
+
 .talkino-email-input {
     width: 40%;
 }
@@ -111,7 +119,7 @@
 }
 
 li.talkino_lineitem {
-    background-color: #7b68ee;
+    background-color: #375da4;
     color: #fff;
     font-size: 14px;
     font-weight: bold;
@@ -133,42 +141,24 @@ li.talkino_lineitem {
 }
 
 #talkino_facebook {
-    background: #1877f2;
+    background: #195199;;
 }
 
 #talkino_telegram {
-    background: #33a8d9;
+    background: #059ad9;
 }
 
 #talkino_phone {
-    background: #696969;
+    background: #474b5e;
 }
 
 #talkino_email {
-    background: #a9a9a9;
+    background: #5e5e5e;
 }
 
-.fab.fa-whatsapp.fa-xl.talkino {
-    padding: 0 5px 0 5px;
-}
-
-.fab.fa-facebook.fa-xl.talkino {
-    padding: 0 5px 0 5px;
-}
-
-.fab.fa-telegram.fa-xl.talkino {
-    padding: 0 5px 0 5px;
-}
-
-.fa.fa-phone.fa-lg.talkino {
-    padding: 0 5px 0 5px;
-}
-
-.fa.fa-envelope.fa-xl.talkino {
-    padding: 0 5px 0 5px;
-}
-
-.fa.fa-user.fa-xl.talkino {
+.talkino-ordering-icon,.dashicons.dashicons-admin-users.talkino {
+    height: 24px;
+    float: left;
     padding: 0 5px 0 5px;
 }
 
@@ -179,92 +169,6 @@ li.talkino_lineitem {
     padding: 2px 5px 2px 5px;
     height: 1.5em;
     line-height: 1.5em;  
-}
-
-/********** Font Awesome Icon Picker **********/
-.talkino-fa-browser-container {
-    background: rgba(0,0,0,0.5);
-    box-sizing: border-box;
-    top: 30px;
-    left: 0;
-    width: 100%;
-    height: 100vh;
-    padding: 1rem;
-    justify-content: center;
-    align-items: center;
-    position: fixed;
-    display: flex;
-}
-
-.talkino-fa-browser-container > .talkino-window {
-    background: white;
-    box-sizing: border-box;
-    border-width: 10px;
-    border-style: solid;
-    border-radius: 10px;
-    position: relative;
-    max-width: 800px;
-    padding: 1rem;
-    width: 100%;
-    height: 100%;
-    z-index: 1;
-    overflow: auto;
-    display: flex;
-    flex-wrap: wrap;
-}
-
-.talkino-fa-browser-container > .talkino-close {
-    color: white;
-    text-shadow: 0 0 10px black;
-    font-size: 36px;
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    z-index: 2;
-    cursor: pointer;
-}
-
-.talkino-fa-browser-container .talkino-icon {
-    font-size: 36px;
-    text-align: center;
-    margin-bottom: 1rem;
-    flex: 0 0 10%;
-    cursor: pointer
-}
-
-.talkino-fa-browser-container .talkino-icon:hover {
-    color: #8f8f8f;
-}
-
-#talkino-icon-container {
-    background: white;
-    text-align: center;
-    border-style: dashed;
-    width: 50px; 
-    padding: 10px 0 10px 0;
-    margin-bottom: 5px;
-    display: block;
-    cursor: pointer;
-}
-
-#talkino-icon-container:hover {
-    background: bottom;
-}
-
-.fa-2xl.talkino {
-    font-size: 2em;
-    line-height: 0.3125em;
-}
-
-/* xs */
-@media (max-width: 575px){
-    .talkino-fa-browser-container .talkino-icon {
-        flex: 0 0 20%;   
-    }
-    .talkino-fa-browser-container > .talkino-close {
-        top: .5rem;
-        right: .5rem;
-    }
 }
 
 /********** Extension **********/

--- a/assets/css/talkino-frontend.css
+++ b/assets/css/talkino-frontend.css
@@ -13,8 +13,12 @@
     display: none !important;
 }
 
-#check:checked~.talkino-chat-btn i {
+#check:checked~.talkino-chat-close .dashicons.dashicons-minus.talkino-chat-close-btn {
     display: block;
+}
+
+#check:checked~.talkino-chat-btn {
+    display: none;
 }
 
 #check:checked~.talkino-chat-btn .talkino-icon {
@@ -33,13 +37,11 @@
     box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
     border: none;
     position: fixed;
-    z-index: 9999999 !important;
     cursor: pointer;
 }
 
 .talkino-chat-btn .talkino-icon {
     color: #fff;
-    font-size: 22px;
     left: 50%;
     top: 50%;
     position: absolute;
@@ -47,26 +49,25 @@
     transform: translate(-50%, -50%);
 }
 
+.round.talkino {
+    width: 30px;
+    height: 30px;
+    font-size: 30px;
+}
+
 .talkino-chat-btn .talkino-rectangle-label {
-    color: #fff;
-    font-size: 14px;
+    font-size: 15px;
     font-weight: bold;
-    text-align: center;
+    text-align: left;
     padding-left: 15px;
     padding-right: 15px;
     margin: 10px;
     white-space: nowrap;
 }
 
-.talkino-chat-btn .talkino-close {
-    color: #fff;
-    font-size: 22px;
-    left: 50%;
-    top: 50%;
-    position: absolute;
-    display: none;
-    transition: all 0.9s ease;
-    transform: translate(-50%, -50%);
+.rectangle.talkino {
+    font-size: 23px;
+    float: right;
 }
 
 label.talkino-chat-btn {
@@ -75,34 +76,45 @@ label.talkino-chat-btn {
 }
 
 .talkino-chat-wrapper {
-    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
-    width: 300px;
+    width: 350px;
+    bottom: 30px;
     position: fixed;
     display: none;
     transition: all 0.4s;
-    z-index: 9999999 !important;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
 }
 
 .talkino-chat-title {
+    font-size: 25px;
+    line-height: 36px;
     padding-top: 5px;
     padding-bottom: 5px;
     padding-left: 15px;
 }
 
+.talkino-chat-close {
+    float: right;
+    margin-top: 10px;
+    margin-right: 10px;
+    cursor: pointer;
+}
+
 .talkino-chat-subtitle {
-    font-size: 13px;
-    padding: 10px 15px 5px 15px;
+    font-size: 16px;
+    padding-top: 13px;
+    padding-left: 15px;
+    padding-bottom: 5px;
+    padding-right: 15px;
 }
 
 .talkino-information-wrapper {
-    max-height: 295px;
+    max-height: 298px;
     overflow-y: auto;
 }
 
 .talkino-information-wrapper::-webkit-scrollbar {
     height: 12px;
     width: 5px;
-    background: #f1f1f1;
 }
 
 .talkino-information-wrapper::-webkit-scrollbar-thumb {
@@ -110,6 +122,7 @@ label.talkino-chat-btn {
 }
 
 .talkino-chat-avatar {
+    float: left;
     position: relative;
 }
 
@@ -121,14 +134,14 @@ label.talkino-chat-btn {
 }
 
 .talkino-channel-icon {
-    top: 22px;
-    left: 15px;
-    padding: 14px;
+    width: 35px !important;
+    top: 29px;
+    left: 28px;
     position: absolute;
 }  
 
 .talkino-notice {
-    font-size: 14px;
+    font-size: 16px;
     text-align: center; 
     margin-top: 25px; 
     margin-bottom: 25px;
@@ -140,48 +153,58 @@ a.talkino-chat-information {
     border-color: darkgray;
     border-radius: 3px;
     border-width: 1px;
-    padding: 7.5px 10px;
+    padding: 12px 0 12px 10px;
     margin: 10px 10px;
-    height: 85px;
     display: block;
     overflow: hidden;
 }
 
-a.talkino-chat-information:hover {
-    background: #f1f1f1;
-}
-
 .talkino-chat-info span {
     display: block;
+    height: 18px;
 }
 
 span.talkino-chat-name {
-    color: #222;
-    font-size: 15px;
+    font-size: 18px;
+    line-height: 27px;
     font-weight: 700;
-    margin: 5px 0 0;
-    height: 20px;
+    height: 25px;
 }
 
 span.talkino-chat-job-title {
-    color: #888;
-    font-size: 12px;
-    height: 15px;
+    font-size: 14px;
+    line-height: 21px;
 }
 
 span.talkino-chat-channel {
-    color: #888;
-    font-size: 12px;
-    height: 30px;
+    font-size: 14px;
+    line-height: 21px;
 }
 
-.rectangle.fa-xl.talkino{
-    font-size: 1.5em;
+.talkino-footer-wrapper {
+    text-align: center;
+    padding-top: 5px;
+    padding-bottom: 10px;
+    font-size: 14px;
+    font-style: italic;
+}
+
+.talkino-credit-link,.talkino-credit-link:hover {
+    text-decoration: none;
+    color: #888;
+}
+
+@media only screen and (max-width: 600px) {
+    .talkino-chat-wrapper {
+        width: 100%;
+        right: 0 !important;
+    }   
 }
 
 /********** Contact Form **********/
 #talkino_contact_form {
     padding: 0 10px 3px 10px;
+    margin-bottom: 10px;
 }
 
 .form-group.talkino {
@@ -195,7 +218,24 @@ span.talkino-chat-channel {
     border-color: darkgray;
     border-width: thin;
     border-radius: 4px;
+}
 
+#talkino_contact_form_name {
+    min-width: 90%;
+    height: 48px;
+    margin: 5px 0px 5px 0;
+}
+
+#talkino_contact_form_email {
+    min-width: 90%;
+    height: 48px;
+    margin: 5px 0px 5px 0;
+}
+
+#talkino_contact_form_message {
+    min-width: 90%;
+    height: 93px;
+    margin: 5px 0px 5px 0;
 }
 
 .spinner-border.talkino {
@@ -206,19 +246,21 @@ span.talkino-chat-channel {
     font-size: 13px;
     font-style: italic;
     color: green;
+    margin: 0;
+    height: 30px;
 }
 
-.btn.btn-primary.submit.talkino {
-    background-color: #0d6efd;
-    color: white;
-    font-size: 13px;
+.talkino-submit-button {
+    font-size: 15px;
+    font-weight: bold;
     text-align: center;
     text-transform: capitalize;
-    text-decoration: none;
+    line-height: 22px;
+    width: 100%;
+    padding: 13px 0 13px 0;
+    margin-bottom: 0;
     border: none;
-    padding: 10px;
-    margin: 4px 2px;
-    display: inline-block;
+    border-radius: 5px !important;  
 }
 
 .grecaptcha-badge {
@@ -227,4 +269,25 @@ span.talkino-chat-channel {
 
 .talkino-google-recaptcha-notice {
     font-size: 13px;
+}
+
+/********** Animation **********/
+@keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+@keyframes slideUp {
+    0%,
+    20% {
+      transform: translateY(100%);
+      opacity: 0;
+    }
+     
+    40%,
+    100% {
+      transform: translateY(0);
+      opacity: 1;
+    
+    }
 }

--- a/assets/js/dashicons-picker.js
+++ b/assets/js/dashicons-picker.js
@@ -1,0 +1,417 @@
+( function ( $ ) {
+	'use strict';
+	/**
+	 *
+	 * @returns {void}
+	 */
+	$.fn.dashiconsPicker = function () {
+
+		/**
+		 * Dashicons, in CSS order
+		 *
+		 * @type Array
+		 */
+		var icons = [
+			'menu',
+			'admin-site',
+			'dashboard',
+			'admin-media',
+			'admin-page',
+			'admin-comments',
+			'admin-appearance',
+			'admin-plugins',
+			'admin-users',
+			'admin-tools',
+			'admin-settings',
+			'admin-network',
+			'admin-generic',
+			'admin-home',
+			'admin-collapse',
+			'filter',
+			'admin-customizer',
+			'admin-multisite',
+			'admin-links',
+			'format-links',
+			'admin-post',
+			'format-standard',
+			'format-image',
+			'format-gallery',
+			'format-audio',
+			'format-video',
+			'format-chat',
+			'format-status',
+			'format-aside',
+			'format-quote',
+			'welcome-write-blog',
+			'welcome-edit-page',
+			'welcome-add-page',
+			'welcome-view-site',
+			'welcome-widgets-menus',
+			'welcome-comments',
+			'welcome-learn-more',
+			'image-crop',
+			'image-rotate',
+			'image-rotate-left',
+			'image-rotate-right',
+			'image-flip-vertical',
+			'image-flip-horizontal',
+			'image-filter',
+			'undo',
+			'redo',
+			'editor-bold',
+			'editor-italic',
+			'editor-ul',
+			'editor-ol',
+			'editor-quote',
+			'editor-alignleft',
+			'editor-aligncenter',
+			'editor-alignright',
+			'editor-insertmore',
+			'editor-spellcheck',
+			'editor-distractionfree',
+			'editor-expand',
+			'editor-contract',
+			'editor-kitchensink',
+			'editor-underline',
+			'editor-justify',
+			'editor-textcolor',
+			'editor-paste-word',
+			'editor-paste-text',
+			'editor-removeformatting',
+			'editor-video',
+			'editor-customchar',
+			'editor-outdent',
+			'editor-indent',
+			'editor-help',
+			'editor-strikethrough',
+			'editor-unlink',
+			'editor-rtl',
+			'editor-break',
+			'editor-code',
+			'editor-paragraph',
+			'editor-table',
+			'align-left',
+			'align-right',
+			'align-center',
+			'align-none',
+			'lock',
+			'unlock',
+			'calendar',
+			'calendar-alt',
+			'visibility',
+			'hidden',
+			'post-status',
+			'edit',
+			'post-trash',
+			'trash',
+			'sticky',
+			'external',
+			'arrow-up',
+			'arrow-down',
+			'arrow-left',
+			'arrow-right',
+			'arrow-up-alt',
+			'arrow-down-alt',
+			'arrow-left-alt',
+			'arrow-right-alt',
+			'arrow-up-alt2',
+			'arrow-down-alt2',
+			'arrow-left-alt2',
+			'arrow-right-alt2',
+			'leftright',
+			'sort',
+			'randomize',
+			'list-view',
+			'excerpt-view',
+			'grid-view',
+			'hammer',
+			'art',
+			'migrate',
+			'performance',
+			'universal-access',
+			'universal-access-alt',
+			'tickets',
+			'nametag',
+			'clipboard',
+			'heart',
+			'megaphone',
+			'schedule',
+			'wordpress',
+			'wordpress-alt',
+			'pressthis',
+			'update',
+			'screenoptions',
+			'cart',
+			'feedback',
+			'cloud',
+			'translation',
+			'tag',
+			'category',
+			'archive',
+			'tagcloud',
+			'text',
+			'media-archive',
+			'media-audio',
+			'media-code',
+			'media-default',
+			'media-document',
+			'media-interactive',
+			'media-spreadsheet',
+			'media-text',
+			'media-video',
+			'playlist-audio',
+			'playlist-video',
+			'controls-play',
+			'controls-pause',
+			'controls-forward',
+			'controls-skipforward',
+			'controls-back',
+			'controls-skipback',
+			'controls-repeat',
+			'controls-volumeon',
+			'controls-volumeoff',
+			'yes',
+			'no',
+			'no-alt',
+			'plus',
+			'plus-alt',
+			'plus-alt2',
+			'minus',
+			'dismiss',
+			'marker',
+			'star-filled',
+			'star-half',
+			'star-empty',
+			'flag',
+			'info',
+			'warning',
+			'share',
+			'share1',
+			'share-alt',
+			'share-alt2',
+			'twitter',
+			'rss',
+			'email',
+			'email-alt',
+			'facebook',
+			'facebook-alt',
+			'networking',
+			'googleplus',
+			'location',
+			'location-alt',
+			'camera',
+			'images-alt',
+			'images-alt2',
+			'video-alt',
+			'video-alt2',
+			'video-alt3',
+			'vault',
+			'shield',
+			'shield-alt',
+			'sos',
+			'search',
+			'slides',
+			'analytics',
+			'chart-pie',
+			'chart-bar',
+			'chart-line',
+			'chart-area',
+			'groups',
+			'businessman',
+			'id',
+			'id-alt',
+			'products',
+			'awards',
+			'forms',
+			'testimonial',
+			'portfolio',
+			'book',
+			'book-alt',
+			'download',
+			'upload',
+			'backup',
+			'clock',
+			'lightbulb',
+			'microphone',
+			'desktop',
+			'tablet',
+			'smartphone',
+			'phone',
+			'smiley',
+			'index-card',
+			'carrot',
+			'building',
+			'store',
+			'album',
+			'palmtree',
+			'tickets-alt',
+			'money',
+			'thumbs-up',
+			'thumbs-down',
+			'layout',
+			'align-pull-left',
+			'align-pull-right',
+			'block-default',
+			'cloud-saved',
+			'cloud-upload',
+			'columns',
+			'cover-image',
+			'embed-audio',
+			'embed-generic',
+			'embed-photo',
+			'embed-post',
+			'embed-video',
+			'exit',
+			'html',
+			'info-outline',
+			'insert-after',
+			'insert-before',
+			'insert',
+			'remove',
+			'shortcode',
+			'table-col-after',
+			'table-col-before',
+			'table-col-delete',
+			'table-row-after',
+			'table-row-before',
+			'table-row-delete',
+			'saved',
+			'amazon',
+			'google',
+			'linkedin',
+			'pinterest',
+			'podio',
+			'reddit',
+			'spotify',
+			'twitch',
+			'whatsapp',
+			'xing',
+			'youtube',
+			'database-add',
+			'database-export',
+			'database-import',
+			'database-remove',
+			'database-view',
+			'database',
+			'bell',
+			'airplane',
+			'car',
+			'calculator',
+			'printer',
+			'beer',
+			'coffee',
+			'drumstick',
+			'food',
+			'bank',
+			'hourglass',
+			'money-alt',
+			'open-folder',
+			'pdf',
+			'pets',
+			'privacy',
+			'superhero',
+			'superhero-alt',
+			'edit-page',
+			'fullscreen-alt',
+			'fullscreen-exit-alt'
+		];
+
+		return this.each( function () {
+
+			var button = $( this ),
+				offsetTop,
+				offsetLeft;
+
+			button.on( 'click.dashiconsPicker', function ( e ) {
+				offsetTop = $( e.currentTarget ).offset().top;
+				offsetLeft = $( e.currentTarget ).offset().left;
+				createPopup( button );
+			} );
+
+			function createPopup( button ) {
+
+				var target = $( button.data( 'target' ) ),
+					preview = $( button.data( 'preview' ) ),
+					popup  = $( '<div class="talkino-dashicon-picker-container">' +
+						'<div class="talkino-dashicon-picker-control"></div>' +
+						'<ul class="talkino-dashicon-picker-list"></ul>' +
+					'</div>' ).css( {
+						'top':  offsetTop,
+						'left': offsetLeft
+					} ),
+					list = popup.find( '.talkino-dashicon-picker-list' );
+
+				for ( var i in icons ) {
+					if ( icons.hasOwnProperty(i) ) {
+						list.append('<li data-icon="' + icons[i] + '"><a href="#" title="' + icons[i] + '"><span class="dashicons dashicons-' + icons[i] + '"></span></a></li>');
+					}
+				}
+
+				$( 'a', list ).on( 'click', function ( e ) {
+					e.preventDefault();
+					var title = $( this ).attr( 'title' );
+					target.val( 'dashicons-' + title );
+					preview
+						.prop('class', 'dashicons')
+						.addClass( 'dashicons-' + title );
+					removePopup();
+				} );
+
+				var control = popup.find( '.talkino-dashicon-picker-control' );
+
+				control.html( '<a data-direction="back" href="#">' +
+					'<span class="dashicons dashicons-arrow-left-alt2"></span></a>' +
+					'<input type="text" class="" placeholder="Search" />' +
+					'<a data-direction="forward" href="#"><span class="dashicons dashicons-arrow-right-alt2"></span></a>'
+				);
+
+				$( 'a', control ).on( 'click', function ( e ) {
+					e.preventDefault();
+					if ( $( this ).data( 'direction' ) === 'back' ) {
+						$( 'li:gt(' + ( icons.length - 26 ) + ')', list ).prependTo( list );
+					} else {
+						$( 'li:lt(25)', list ).appendTo( list );
+					}
+				} );
+
+				popup.appendTo( 'body' ).show();
+
+				$( 'input', control ).on( 'keyup', function ( e ) {
+					var search = $( this ).val();
+					if ( search === '' ) {
+						$( 'li:lt(25)', list ).show();
+					} else {
+						$( 'li', list ).each( function () {
+							if ( $( this ).data( 'icon' ).toLowerCase().indexOf( search.toLowerCase() ) !== -1 ) {
+								$( this ).show();
+							} else {
+								$( this ).hide();
+							}
+						} );
+					}
+				} );
+
+				$( document ).on( 'mouseup.dashicons-picker', function ( e ) {
+					if ( ! popup.is( e.target ) && popup.has( e.target ).length === 0 ) {
+						removePopup();
+					}
+				} );
+			}
+
+			function removePopup() {
+				$( '.talkino-dashicon-picker-container' ).remove();
+				$( document ).off( '.dashicons-picker' );
+
+				// Preview icon.
+				var icon_class = document.getElementById( "talkino_dashicons_picker" ).value;
+                $( '#talkino-icon-preview' ).replaceWith( '<i id="talkino-icon-preview" class="dashicons '+icon_class+' talkino"></i></div>' );
+
+			}
+		} );
+	};
+
+	$( function () {
+		$( '.dashicons-picker' ).dashiconsPicker();
+	} );
+
+}( jQuery ) );

--- a/assets/js/talkino-admin.js
+++ b/assets/js/talkino-admin.js
@@ -1,5 +1,526 @@
 jQuery( document ).ready( function( $ ) {
 
+	$( '#talkino_template_color_default' ).click( function( event ) {   
+		
+		$( '#talkino_chatbox_online_theme_color' ).val( '#1e73be' );
+		$( '#talkino_chatbox_online_theme_color.color-picker' ).wpColorPicker( 'color', '#1e73be' );
+
+		$( '#talkino_chatbox_online_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_online_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_away_theme_color' ).val( '#ff6000' );
+		$( '#talkino_chatbox_away_theme_color.color-picker' ).wpColorPicker( 'color', '#ff6000' );
+
+		$( '#talkino_chatbox_away_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_away_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_offline_theme_color' ).val( '#727779' );
+		$( '#talkino_chatbox_offline_theme_color.color-picker' ).wpColorPicker( 'color', '#727779' );
+
+		$( '#talkino_chatbox_offline_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_offline_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_background_color' ).val( '#f0f0f1' );
+		$( '#talkino_chatbox_background_color.color-picker' ).wpColorPicker( 'color', '#f0f0f1' );
+
+		$( '#talkino_chatbox_title_color' ).val( '#fff' );
+		$( '#talkino_chatbox_title_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_subtitle_color' ).val( '#000' );
+		$( '#talkino_chatbox_subtitle_color.color-picker' ).wpColorPicker( 'color', '#000' );
+
+		$( '#talkino_chatbox_button_color' ).val( '#727779' );
+		$( '#talkino_chatbox_button_color.color-picker' ).wpColorPicker( 'color', '#727779' );
+
+		$( '#talkino_chatbox_button_text_color' ).val( '#fff' );
+		$( '#talkino_chatbox_button_text_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+		
+		$( '#talkino_agent_field_background_color' ).val( '#fff' );
+		$( '#talkino_agent_field_background_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_hover_background_color' ).val( '#dfdfdf' );
+		$( '#talkino_agent_field_hover_background_color.color-picker' ).wpColorPicker( 'color', '#dfdfdf' );
+		
+		$( '#talkino_agent_name_text_color' ).val( '#222' );
+		$( '#talkino_agent_name_text_color.color-picker' ).wpColorPicker( 'color', '#222' );
+		
+		$( '#talkino_agent_job_title_text_color' ).val( '#888' );
+		$( '#talkino_agent_job_title_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+		
+		$( '#talkino_agent_channel_text_color' ).val( '#888' );
+		$( '#talkino_agent_channel_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+			
+	}); 
+
+	$( '#talkino_template_color_sky' ).click( function( event ) {   
+		
+		$( '#talkino_chatbox_online_theme_color' ).val( '#00c3ff' );
+		$( '#talkino_chatbox_online_theme_color.color-picker' ).wpColorPicker( 'color', '#00c3ff' );
+
+		$( '#talkino_chatbox_online_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_online_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_away_theme_color' ).val( '#5d87b5' );
+		$( '#talkino_chatbox_away_theme_color.color-picker' ).wpColorPicker( 'color', '#5d87b5' );
+
+		$( '#talkino_chatbox_away_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_away_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_offline_theme_color' ).val( '#527a86' );
+		$( '#talkino_chatbox_offline_theme_color.color-picker' ).wpColorPicker( 'color', '#527a86' );
+
+		$( '#talkino_chatbox_offline_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_offline_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_background_color' ).val( '#f0f0f1' );
+		$( '#talkino_chatbox_background_color.color-picker' ).wpColorPicker( 'color', '#f0f0f1' );
+
+		$( '#talkino_chatbox_title_color' ).val( '#fff' );
+		$( '#talkino_chatbox_title_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_subtitle_color' ).val( '#000' );
+		$( '#talkino_chatbox_subtitle_color.color-picker' ).wpColorPicker( 'color', '#000' );
+
+		$( '#talkino_chatbox_button_color' ).val( '#527a86' );
+		$( '#talkino_chatbox_button_color.color-picker' ).wpColorPicker( 'color', '#527a86' );
+
+		$( '#talkino_chatbox_button_text_color' ).val( '#fff' );
+		$( '#talkino_chatbox_button_text_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_background_color' ).val( '#fff' );
+		$( '#talkino_agent_field_background_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_hover_background_color' ).val( '#dff3f5' );
+		$( '#talkino_agent_field_hover_background_color.color-picker' ).wpColorPicker( 'color', '#dff3f5' );
+		
+		$( '#talkino_agent_name_text_color' ).val( '#222' );
+		$( '#talkino_agent_name_text_color.color-picker' ).wpColorPicker( 'color', '#222' );
+		
+		$( '#talkino_agent_job_title_text_color' ).val( '#888' );
+		$( '#talkino_agent_job_title_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+		
+		$( '#talkino_agent_channel_text_color' ).val( '#888' );
+		$( '#talkino_agent_channel_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+			
+	}); 
+
+	$( '#talkino_template_color_fashion' ).click( function( event ) {   
+		
+		$( '#talkino_chatbox_online_theme_color' ).val( '#6e3abb' );
+		$( '#talkino_chatbox_online_theme_color.color-picker' ).wpColorPicker( 'color', '#6e3abb' );
+
+		$( '#talkino_chatbox_online_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_online_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_away_theme_color' ).val( '#668bbb' );
+		$( '#talkino_chatbox_away_theme_color.color-picker' ).wpColorPicker( 'color', '#668bbb' );
+
+		$( '#talkino_chatbox_away_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_away_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_offline_theme_color' ).val( '#646480' );
+		$( '#talkino_chatbox_offline_theme_color.color-picker' ).wpColorPicker( 'color', '#646480' );
+
+		$( '#talkino_chatbox_offline_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_offline_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_background_color' ).val( '#f0f0f1' );
+		$( '#talkino_chatbox_background_color.color-picker' ).wpColorPicker( 'color', '#f0f0f1' );
+
+		$( '#talkino_chatbox_title_color' ).val( '#fff' );
+		$( '#talkino_chatbox_title_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_subtitle_color' ).val( '#000' );
+		$( '#talkino_chatbox_subtitle_color.color-picker' ).wpColorPicker( 'color', '#000' );
+
+		$( '#talkino_chatbox_button_color' ).val( '#646480' );
+		$( '#talkino_chatbox_button_color.color-picker' ).wpColorPicker( 'color', '#646480' );
+
+		$( '#talkino_chatbox_button_text_color' ).val( '#fff' );
+		$( '#talkino_chatbox_button_text_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_background_color' ).val( '#fff' );
+		$( '#talkino_agent_field_background_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_hover_background_color' ).val( '#ebdcfd' );
+		$( '#talkino_agent_field_hover_background_color.color-picker' ).wpColorPicker( 'color', '#ebdcfd' );
+		
+		$( '#talkino_agent_name_text_color' ).val( '#222' );
+		$( '#talkino_agent_name_text_color.color-picker' ).wpColorPicker( 'color', '#222' );
+		
+		$( '#talkino_agent_job_title_text_color' ).val( '#888' );
+		$( '#talkino_agent_job_title_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+		
+		$( '#talkino_agent_channel_text_color' ).val( '#888' );
+		$( '#talkino_agent_channel_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+			
+	}); 
+
+	$( '#talkino_template_color_passion' ).click( function( event ) {   
+		
+		$( '#talkino_chatbox_online_theme_color' ).val( '#dd3333' );
+		$( '#talkino_chatbox_online_theme_color.color-picker' ).wpColorPicker( 'color', '#dd3333' );
+
+		$( '#talkino_chatbox_online_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_online_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_away_theme_color' ).val( '#ff6000' );
+		$( '#talkino_chatbox_away_theme_color.color-picker' ).wpColorPicker( 'color', '#ff6000' );
+
+		$( '#talkino_chatbox_away_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_away_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_offline_theme_color' ).val( '#330a0a' );
+		$( '#talkino_chatbox_offline_theme_color.color-picker' ).wpColorPicker( 'color', '#330a0a' );
+
+		$( '#talkino_chatbox_offline_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_offline_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_background_color' ).val( '#f0f0f1' );
+		$( '#talkino_chatbox_background_color.color-picker' ).wpColorPicker( 'color', '#f0f0f1' );
+
+		$( '#talkino_chatbox_title_color' ).val( '#fff' );
+		$( '#talkino_chatbox_title_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_subtitle_color' ).val( '#000' );
+		$( '#talkino_chatbox_subtitle_color.color-picker' ).wpColorPicker( 'color', '#000' );
+
+		$( '#talkino_chatbox_button_color' ).val( '#330a0a' );
+		$( '#talkino_chatbox_button_color.color-picker' ).wpColorPicker( 'color', '#330a0a' );
+
+		$( '#talkino_chatbox_button_text_color' ).val( '#fff' );
+		$( '#talkino_chatbox_button_text_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_background_color' ).val( '#fff' );
+		$( '#talkino_agent_field_background_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_hover_background_color' ).val( '#dfdfdf' );
+		$( '#talkino_agent_field_hover_background_color.color-picker' ).wpColorPicker( 'color', '#dfdfdf' );
+		
+		$( '#talkino_agent_name_text_color' ).val( '#222222' );
+		$( '#talkino_agent_name_text_color.color-picker' ).wpColorPicker( 'color', '#222222' );
+		
+		$( '#talkino_agent_job_title_text_color' ).val( '#888' );
+		$( '#talkino_agent_job_title_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+		
+		$( '#talkino_agent_channel_text_color' ).val( '#888' );
+		$( '#talkino_agent_channel_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+			
+	}); 
+
+	$( '#talkino_template_color_confidence' ).click( function( event ) {   
+		
+		$( '#talkino_chatbox_online_theme_color' ).val( '#ff8100' );
+		$( '#talkino_chatbox_online_theme_color.color-picker' ).wpColorPicker( 'color', '#ff8100' );
+
+		$( '#talkino_chatbox_online_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_online_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_away_theme_color' ).val( '#ffc301' );
+		$( '#talkino_chatbox_away_theme_color.color-picker' ).wpColorPicker( 'color', '#ffc301' );
+
+		$( '#talkino_chatbox_away_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_away_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_offline_theme_color' ).val( '#bf5305' );
+		$( '#talkino_chatbox_offline_theme_color.color-picker' ).wpColorPicker( 'color', '#bf5305' );
+
+		$( '#talkino_chatbox_offline_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_offline_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_background_color' ).val( '#fff' );
+		$( '#talkino_chatbox_background_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_title_color' ).val( '#fff' );
+		$( '#talkino_chatbox_title_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_subtitle_color' ).val( '#000' );
+		$( '#talkino_chatbox_subtitle_color.color-picker' ).wpColorPicker( 'color', '#000' );
+
+		$( '#talkino_chatbox_button_color' ).val( '#bf5305' );
+		$( '#talkino_chatbox_button_color.color-picker' ).wpColorPicker( 'color', '#bf5305' );
+
+		$( '#talkino_chatbox_button_text_color' ).val( '#fff' );
+		$( '#talkino_chatbox_button_text_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_background_color' ).val( '#fff' );
+		$( '#talkino_agent_field_background_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_hover_background_color' ).val( '#dfdfdf' );
+		$( '#talkino_agent_field_hover_background_color.color-picker' ).wpColorPicker( 'color', '#dfdfdf' );
+		
+		$( '#talkino_agent_name_text_color' ).val( '#222222' );
+		$( '#talkino_agent_name_text_color.color-picker' ).wpColorPicker( 'color', '#222222' );
+		
+		$( '#talkino_agent_job_title_text_color' ).val( '#888' );
+		$( '#talkino_agent_job_title_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+		
+		$( '#talkino_agent_channel_text_color' ).val( '#888' );
+		$( '#talkino_agent_channel_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+			
+	}); 
+
+	$( '#talkino_template_color_sunshine' ).click( function( event ) {   
+		
+		$( '#talkino_chatbox_online_theme_color' ).val( '#ffb300' );
+		$( '#talkino_chatbox_online_theme_color.color-picker' ).wpColorPicker( 'color', '#ffb300' );
+
+		$( '#talkino_chatbox_online_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_online_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_away_theme_color' ).val( '#e65b08' );
+		$( '#talkino_chatbox_away_theme_color.color-picker' ).wpColorPicker( 'color', '#e65b08' );
+
+		$( '#talkino_chatbox_away_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_away_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_offline_theme_color' ).val( '#a86f4d' );
+		$( '#talkino_chatbox_offline_theme_color.color-picker' ).wpColorPicker( 'color', '#a86f4d' );
+
+		$( '#talkino_chatbox_offline_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_offline_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_background_color' ).val( '#fff' );
+		$( '#talkino_chatbox_background_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_title_color' ).val( '#fff' );
+		$( '#talkino_chatbox_title_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_subtitle_color' ).val( '#000' );
+		$( '#talkino_chatbox_subtitle_color.color-picker' ).wpColorPicker( 'color', '#000' );
+
+		$( '#talkino_chatbox_button_color' ).val( '#a86f4d' );
+		$( '#talkino_chatbox_button_color.color-picker' ).wpColorPicker( 'color', '#a86f4d' );
+
+		$( '#talkino_chatbox_button_text_color' ).val( '#fff' );
+		$( '#talkino_chatbox_button_text_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_background_color' ).val( '#fff' );
+		$( '#talkino_agent_field_background_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_hover_background_color' ).val( '#dfdfdf' );
+		$( '#talkino_agent_field_hover_background_color.color-picker' ).wpColorPicker( 'color', '#dfdfdf' );
+		
+		$( '#talkino_agent_name_text_color' ).val( '#222222' );
+		$( '#talkino_agent_name_text_color.color-picker' ).wpColorPicker( 'color', '#222222' );
+		
+		$( '#talkino_agent_job_title_text_color' ).val( '#888' );
+		$( '#talkino_agent_job_title_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+		
+		$( '#talkino_agent_channel_text_color' ).val( '#888' );
+		$( '#talkino_agent_channel_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+			
+	}); 
+
+	$( '#talkino_template_color_forest' ).click( function( event ) {   
+		
+		$( '#talkino_chatbox_online_theme_color' ).val( '#185121' );
+		$( '#talkino_chatbox_online_theme_color.color-picker' ).wpColorPicker( 'color', '#185121' );
+
+		$( '#talkino_chatbox_online_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_online_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_away_theme_color' ).val( '#57a657' );
+		$( '#talkino_chatbox_away_theme_color.color-picker' ).wpColorPicker( 'color', '#57a657' );
+
+		$( '#talkino_chatbox_away_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_away_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_offline_theme_color' ).val( '#748f6f' );
+		$( '#talkino_chatbox_offline_theme_color.color-picker' ).wpColorPicker( 'color', '#748f6f' );
+
+		$( '#talkino_chatbox_offline_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_offline_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_background_color' ).val( '#fff' );
+		$( '#talkino_chatbox_background_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_title_color' ).val( '#fff' );
+		$( '#talkino_chatbox_title_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_subtitle_color' ).val( '#000' );
+		$( '#talkino_chatbox_subtitle_color.color-picker' ).wpColorPicker( 'color', '#000' );
+
+		$( '#talkino_chatbox_button_color' ).val( '#748f6f' );
+		$( '#talkino_chatbox_button_color.color-picker' ).wpColorPicker( 'color', '#748f6f' );
+
+		$( '#talkino_chatbox_button_text_color' ).val( '#fff' );
+		$( '#talkino_chatbox_button_text_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_background_color' ).val( '#fff' );
+		$( '#talkino_agent_field_background_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_hover_background_color' ).val( '#dff0c6' );
+		$( '#talkino_agent_field_hover_background_color.color-picker' ).wpColorPicker( 'color', '#dff0c6' );
+		
+		$( '#talkino_agent_name_text_color' ).val( '#222222' );
+		$( '#talkino_agent_name_text_color.color-picker' ).wpColorPicker( 'color', '#222222' );
+		
+		$( '#talkino_agent_job_title_text_color' ).val( '#888' );
+		$( '#talkino_agent_job_title_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+		
+		$( '#talkino_agent_channel_text_color' ).val( '#888' );
+		$( '#talkino_agent_channel_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+			
+	}); 
+	
+	$( '#talkino_template_color_mint' ).click( function( event ) {   
+		
+		$( '#talkino_chatbox_online_theme_color' ).val( '#7ecc7e' );
+		$( '#talkino_chatbox_online_theme_color.color-picker' ).wpColorPicker( 'color', '#7ecc7e' );
+
+		$( '#talkino_chatbox_online_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_online_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_away_theme_color' ).val( '#7ea87e' );
+		$( '#talkino_chatbox_away_theme_color.color-picker' ).wpColorPicker( 'color', '#7ea87e' );
+
+		$( '#talkino_chatbox_away_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_away_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_offline_theme_color' ).val( '#9dbd9d' );
+		$( '#talkino_chatbox_offline_theme_color.color-picker' ).wpColorPicker( 'color', '#9dbd9d' );
+
+		$( '#talkino_chatbox_offline_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_offline_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_background_color' ).val( '#fff' );
+		$( '#talkino_chatbox_background_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_title_color' ).val( '#fff' );
+		$( '#talkino_chatbox_title_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_subtitle_color' ).val( '#000' );
+		$( '#talkino_chatbox_subtitle_color.color-picker' ).wpColorPicker( 'color', '#000' );
+
+		$( '#talkino_chatbox_button_color' ).val( '#9dbd9d' );
+		$( '#talkino_chatbox_button_color.color-picker' ).wpColorPicker( 'color', '#9dbd9d' );
+
+		$( '#talkino_chatbox_button_text_color' ).val( '#fff' );
+		$( '#talkino_chatbox_button_text_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_background_color' ).val( '#fff' );
+		$( '#talkino_agent_field_background_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_hover_background_color' ).val( '#d6ffd6' );
+		$( '#talkino_agent_field_hover_background_color.color-picker' ).wpColorPicker( 'color', '#d6ffd6' );
+		
+		$( '#talkino_agent_name_text_color' ).val( '#222222' );
+		$( '#talkino_agent_name_text_color.color-picker' ).wpColorPicker( 'color', '#222222' );
+		
+		$( '#talkino_agent_job_title_text_color' ).val( '#888' );
+		$( '#talkino_agent_job_title_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+		
+		$( '#talkino_agent_channel_text_color' ).val( '#888' );
+		$( '#talkino_agent_channel_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+			
+	}); 
+
+	$( '#talkino_template_color_coffee' ).click( function( event ) {   
+		
+		$( '#talkino_chatbox_online_theme_color' ).val( '#863d26' );
+		$( '#talkino_chatbox_online_theme_color.color-picker' ).wpColorPicker( 'color', '#863d26' );
+
+		$( '#talkino_chatbox_online_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_online_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_away_theme_color' ).val( '#866155' );
+		$( '#talkino_chatbox_away_theme_color.color-picker' ).wpColorPicker( 'color', '#866155' );
+
+		$( '#talkino_chatbox_away_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_away_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_offline_theme_color' ).val( '#46342d' );
+		$( '#talkino_chatbox_offline_theme_color.color-picker' ).wpColorPicker( 'color', '#46342d' );
+
+		$( '#talkino_chatbox_offline_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_offline_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_background_color' ).val( '#f0f0f1' );
+		$( '#talkino_chatbox_background_color.color-picker' ).wpColorPicker( 'color', '#f0f0f1' );
+
+		$( '#talkino_chatbox_title_color' ).val( '#fff' );
+		$( '#talkino_chatbox_title_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_subtitle_color' ).val( '#000' );
+		$( '#talkino_chatbox_subtitle_color.color-picker' ).wpColorPicker( 'color', '#000' );
+
+		$( '#talkino_chatbox_button_color' ).val( '#46342d' );
+		$( '#talkino_chatbox_button_color.color-picker' ).wpColorPicker( 'color', '#46342d' );
+
+		$( '#talkino_chatbox_button_text_color' ).val( '#fff' );
+		$( '#talkino_chatbox_button_text_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_background_color' ).val( '#fff' );
+		$( '#talkino_agent_field_background_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_hover_background_color' ).val( '#dfdfdf' );
+		$( '#talkino_agent_field_hover_background_color.color-picker' ).wpColorPicker( 'color', '#dfdfdf' );
+		
+		$( '#talkino_agent_name_text_color' ).val( '#222222' );
+		$( '#talkino_agent_name_text_color.color-picker' ).wpColorPicker( 'color', '#222222' );
+		
+		$( '#talkino_agent_job_title_text_color' ).val( '#888' );
+		$( '#talkino_agent_job_title_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+		
+		$( '#talkino_agent_channel_text_color' ).val( '#888' );
+		$( '#talkino_agent_channel_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+			
+	}); 
+
+	$( '#talkino_template_color_midnight' ).click( function( event ) {   
+		
+		$( '#talkino_chatbox_online_theme_color' ).val( '#2b2827' );
+		$( '#talkino_chatbox_online_theme_color.color-picker' ).wpColorPicker( 'color', '#2b2827' );
+
+		$( '#talkino_chatbox_online_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_online_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_away_theme_color' ).val( '#575453' );
+		$( '#talkino_chatbox_away_theme_color.color-picker' ).wpColorPicker( 'color', '#575453' );
+
+		$( '#talkino_chatbox_away_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_away_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_offline_theme_color' ).val( '#a8a8a8' );
+		$( '#talkino_chatbox_offline_theme_color.color-picker' ).wpColorPicker( 'color', '#a8a8a8' );
+
+		$( '#talkino_chatbox_offline_icon_color' ).val( '#fff' );
+		$( '#talkino_chatbox_offline_icon_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_background_color' ).val( '#f0f0f1' );
+		$( '#talkino_chatbox_background_color.color-picker' ).wpColorPicker( 'color', '#f0f0f1' );
+
+		$( '#talkino_chatbox_title_color' ).val( '#fff' );
+		$( '#talkino_chatbox_title_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_chatbox_subtitle_color' ).val( '#000' );
+		$( '#talkino_chatbox_subtitle_color.color-picker' ).wpColorPicker( 'color', '#000' );
+
+		$( '#talkino_chatbox_button_color' ).val( '#a8a8a8' );
+		$( '#talkino_chatbox_button_color.color-picker' ).wpColorPicker( 'color', '#a8a8a8' );
+
+		$( '#talkino_chatbox_button_text_color' ).val( '#fff' );
+		$( '#talkino_chatbox_button_text_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_background_color' ).val( '#fff' );
+		$( '#talkino_agent_field_background_color.color-picker' ).wpColorPicker( 'color', '#fff' );
+
+		$( '#talkino_agent_field_hover_background_color' ).val( '#dfdfdf' );
+		$( '#talkino_agent_field_hover_background_color.color-picker' ).wpColorPicker( 'color', '#dfdfdf' );
+		
+		$( '#talkino_agent_name_text_color' ).val( '#222222' );
+		$( '#talkino_agent_name_text_color.color-picker' ).wpColorPicker( 'color', '#222222' );
+		
+		$( '#talkino_agent_job_title_text_color' ).val( '#888' );
+		$( '#talkino_agent_job_title_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+		
+		$( '#talkino_agent_channel_text_color' ).val( '#888' );
+		$( '#talkino_agent_channel_text_color.color-picker' ).wpColorPicker( 'color', '#888' );
+			
+	}); 
+
+
 	/******************** Channel order list ********************/
 	// Action url for ajax.
 	var wpajax_url_sort_channel = ajax_object.ajax_url + '?action=talkino_update_channel_order_list';

--- a/includes/admin/class-talkino-admin.php
+++ b/includes/admin/class-talkino-admin.php
@@ -82,8 +82,8 @@ class Talkino_Admin {
 
 			wp_enqueue_style( 'talkino-admin', plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/css/talkino-admin.css', array(), $this->version, 'all' );
 
-			// Enqueue font awesome css for admin area.
-			wp_enqueue_style( 'font-awesome-min', plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/fontawesome-free-6.2.0-web/css/all.min.css', array(), '6.2.0', 'all' );
+			// Enqueue dashicons picker for admin area.
+			wp_enqueue_style( 'dashicons-picker', plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/css/dashicons-picker.css', array( 'dashicons' ), $this->version, 'all' );
 
 		}
 
@@ -112,8 +112,8 @@ class Talkino_Admin {
 			// Enqueue jquery for sorting.
 			wp_enqueue_script( 'jquery-ui-sortable', false, array( 'jquery-ui-core', 'jquery' ), $this->version, true );
 
-			// Enqueue jquery for picking icon.
-			wp_enqueue_script( 'icon-picker', plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/js/icon-picker.js', array( 'jquery' ), $this->version, true );
+			// Enqueue jquery for dashicons picker.
+			wp_enqueue_script( 'dashicons-picker', plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/js/dashicons-picker.js', array( 'jquery' ), $this->version, true );
 
 			// Pass $php_vars array to javascript as php object for channel ordering.
 			$ajax_url = array( 'ajax_url' => admin_url( 'admin-ajax.php' ) );

--- a/includes/admin/class-talkino-customizer.php
+++ b/includes/admin/class-talkino-customizer.php
@@ -102,11 +102,11 @@ class Talkino_Customizer {
 			2  => esc_html__( 'Agent field updated.', 'talkino' ),
 			3  => esc_html__( 'Agent field deleted.', 'talkino' ),
 			4  => esc_html__( 'Agent updated.', 'talkino' ),
-			5  => isset( $_GET['revision'] ) ? sprintf( esc_html__( 'Agent restored to revision from %s', 'talkino' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false, // phpcs:ignore
+			5  => isset( $_GET['revision'] ) ? sprintf( esc_html__( 'Agent restored to revision from %s', 'talkino' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
 			6  => esc_html__( 'Agent published. Please clear your cache if you are using any caching plugin.', 'talkino' ),
 			7  => esc_html__( 'Agent saved.', 'talkino' ),
 			8  => esc_html__( 'Agent submitted.', 'talkino' ),
-			9  => sprintf( esc_html__( 'Agent scheduled for: <strong>%1$s</strong>.', 'talkino' ), date_i18n( esc_html( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ) ), // phpcs:ignore
+			9  => sprintf( esc_html__( 'Agent scheduled for: <strong>%1$s</strong>.', 'talkino' ), date_i18n( esc_html( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ) ),
 			10 => esc_html__( 'Agent draft updated.', 'talkino' ),
 		);
 
@@ -126,14 +126,34 @@ class Talkino_Customizer {
 	public function edit_bulk_post_updated_messages( $bulk_messages, $bulk_counts ) {
 
 		$bulk_messages['talkino_agents'] = array(
-			'updated'   => _n( '%s agent updated.', '%s agents updated.', $bulk_counts['updated'], 'talkino' ), // phpcs:ignore
-			'locked'    => _n( '%s agent not updated, somebody is editing it.', '%s agents not updated, somebody is editing them.', $bulk_counts['locked'], 'talkino' ), // phpcs:ignore
-			'deleted'   => _n( '%s agent permanently deleted.', '%s agents permanently deleted.', $bulk_counts['deleted'], 'talkino'), // phpcs:ignore
-			'trashed'   => _n( '%s agent moved to the Trash. Please clear your cache if you are using any caching plugin.', '%s agents moved to the Trash. Please clear your cache if you are using any cache plugin.', $bulk_counts['trashed'], 'talkino' ), // phpcs:ignore
-			'untrashed' => _n( '%s agent restored from the Trash.', '%s agents restored from the Trash.', $bulk_counts['untrashed'], 'talkino' ), // phpcs:ignore
+			'updated'   => _n( '%s agent updated.', '%s agents updated.', $bulk_counts['updated'], 'talkino' ),
+			'locked'    => _n( '%s agent not updated, somebody is editing it.', '%s agents not updated, somebody is editing them.', $bulk_counts['locked'], 'talkino' ),
+			'deleted'   => _n( '%s agent permanently deleted.', '%s agents permanently deleted.', $bulk_counts['deleted'], 'talkino'),
+			'trashed'   => _n( '%s agent moved to the Trash. Please clear your cache if you are using any caching plugin.', '%s agents moved to the Trash. Please clear your cache if you are using any cache plugin.', $bulk_counts['trashed'], 'talkino' ),
+			'untrashed' => _n( '%s agent restored from the Trash.', '%s agents restored from the Trash.', $bulk_counts['untrashed'], 'talkino' ),
 		);
 
 		return $bulk_messages;
+
+	}
+
+	/**
+	 * Add link to options page on plugins page
+	 *
+	 * @since    2.0.0
+	 * @param    array $links    current plugin links.
+	 * 
+	 * @return   array    $links    new plugin links. 
+	 */
+	public function add_premium_plugin_link( $links ) {
+
+		$links['premium'] = sprintf(
+			'<a href="%1$s" target="_blank" style="font-weight:bold; color:#f9603a; ">%2$s</a>',
+			esc_url( "https://traxconn.com/plugins/talkino" ),
+			esc_html__( 'Premium', 'talkino' )
+		);
+
+		return $links;
 
 	}
 

--- a/includes/admin/class-talkino-post-type.php
+++ b/includes/admin/class-talkino-post-type.php
@@ -65,7 +65,7 @@ class Talkino_Post_Type {
 			'has_archive'           => false,
 			'show_in_menu'          => true,
 			'show_in_nav_menus'     => true,
-			'menu_icon'             => 'dashicons-admin-users',
+			'menu_icon'             => 'dashicons-format-chat',
 			'delete_with_user'      => false,
 			'exclude_from_search'   => true,
 			'capability_type'       => 'post',

--- a/includes/admin/class-talkino-sanitizer.php
+++ b/includes/admin/class-talkino-sanitizer.php
@@ -113,4 +113,26 @@ class Talkino_Sanitizer {
 
 	}
 
+	/**
+	 * The function to sanitize checkbox of phone show only on mobile status.
+	 *
+	 * @since    2.0.0
+	 * @param    string $phone_show_only_on_mobile_status    The phone show only on mobile status.
+	 *
+	 * @return   string    The sanitized phone show only on mobile status.
+	 */
+	public function sanitize_phone_show_only_on_mobile_status( $phone_show_only_on_mobile_status ) {
+
+		if ( 'on' === $phone_show_only_on_mobile_status || 'off' === $phone_show_only_on_mobile_status ) {
+			$phone_show_only_on_mobile_status = $phone_show_only_on_mobile_status;
+
+		} else {
+			$phone_show_only_on_mobile_status = 'off';
+
+		}
+
+		return $phone_show_only_on_mobile_status;
+
+	}
+
 }

--- a/includes/admin/class-talkino-settings.php
+++ b/includes/admin/class-talkino-settings.php
@@ -47,7 +47,7 @@ class Talkino_Settings {
 		}
 
 		$default_tab = null;
-		$tab         = isset( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : $default_tab; // phpcs:ignore
+		$tab         = isset( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : $default_tab;
 
 		?>
 		<div class="wrap">
@@ -73,6 +73,8 @@ class Talkino_Settings {
 					<?php
 				}
 				?>
+				<a href="?post_type=talkino_agents&page=talkino_settings_page&tab=credit" class="nav-tab <?php if ( 'credit' === $tab ) : ?>
+				nav-tab-active<?php endif; ?>"><?php esc_html_e( 'Credit', 'talkino' ); ?></a>
 				<a href="?post_type=talkino_agents&page=talkino_settings_page&tab=advanced" class="nav-tab <?php if ( 'advanced' === $tab ) : ?>
 					nav-tab-active<?php endif; ?>"><?php esc_html_e( 'Advanced', 'talkino' ); ?></a>
 			</nav>			
@@ -150,22 +152,44 @@ class Talkino_Settings {
 
 						case 'contact-form':
 							?>
-						<div class="wrap">
-							<form action="options.php" method="post">
-								<?php
-								// Show error or update message.
-								settings_errors();
+							<div class="wrap">
+								<form action="options.php" method="post">
+									<?php
+									// Show error or update message.
+									settings_errors();
 
-								// Output security fields for the registered contact form page.
-								settings_fields( 'talkino_contact_form_page' );
+									// Output security fields for the registered contact form page.
+									settings_fields( 'talkino_contact_form_page' );
 
-								// Output contact form sections and fields.
-								do_settings_sections( 'talkino_contact_form_page' );
-								submit_button( esc_html__( 'Save Settings', 'talkino' ) );
+									// Output contact form sections and fields.
+									do_settings_sections( 'talkino_contact_form_page' );
+									submit_button( esc_html__( 'Save Settings', 'talkino' ) );
 
-								?>
-							</form>
-						</div>
+									?>
+								</form>
+							</div>
+							<?php
+							break;
+
+						case 'credit':
+							?>
+							<div class="wrap">
+								<form action="options.php" method="post">
+									<?php
+									// Show error or update message.
+									settings_errors();
+
+									// Output security fields for the registered advanced page.
+									settings_fields( 'talkino_credit_page' );
+
+									// Output advanced sections and fields.
+									do_settings_sections( 'talkino_credit_page' );
+
+									// Output save settings button.
+									submit_button( esc_html__( 'Save Settings', 'talkino' ) );
+									?>
+								</form>
+							</div>
 							<?php
 							break;
 
@@ -284,7 +308,7 @@ class Talkino_Settings {
 							<?php
 							break;
 
-						case 'advanced':
+						case 'credit':
 							?>
 							<div class="wrap">
 								<form action="options.php" method="post">
@@ -293,10 +317,10 @@ class Talkino_Settings {
 									settings_errors();
 
 									// Output security fields for the registered advanced page.
-									settings_fields( 'talkino_advanced_page' );
+									settings_fields( 'talkino_credit_page' );
 
 									// Output advanced sections and fields.
-									do_settings_sections( 'talkino_advanced_page' );
+									do_settings_sections( 'talkino_credit_page' );
 
 									// Output save settings button.
 									submit_button( esc_html__( 'Save Settings', 'talkino' ) );
@@ -305,6 +329,28 @@ class Talkino_Settings {
 							</div>
 							<?php
 							break;
+
+							case 'advanced':
+								?>
+								<div class="wrap">
+									<form action="options.php" method="post">
+										<?php
+										// Show error or update message.
+										settings_errors();
+	
+										// Output security fields for the registered advanced page.
+										settings_fields( 'talkino_advanced_page' );
+	
+										// Output advanced sections and fields.
+										do_settings_sections( 'talkino_advanced_page' );
+	
+										// Output save settings button.
+										submit_button( esc_html__( 'Save Settings', 'talkino' ) );
+										?>
+									</form>
+								</div>
+								<?php
+								break;
 
 						default:
 							?>
@@ -393,6 +439,30 @@ class Talkino_Settings {
 			'talkino_styles_page'
 		);
 
+		// Register template section in the talkino styles page.
+		add_settings_section(
+			'talkino_template_section',
+			esc_html__( 'Template', 'talkino' ),
+			array( $this, 'template_section_callback' ),
+			'talkino_styles_page'
+		);
+
+		// Register chatbox color section in the talkino styles page.
+		add_settings_section(
+			'talkino_chatbox_color_section',
+			esc_html__( 'Chatbox Color', 'talkino' ),
+			array( $this, 'color_section_callback' ),
+			'talkino_styles_page'
+		);
+
+		// Register agent field color section in the talkino styles page.
+		add_settings_section(
+			'talkino_agent_field_color_section',
+			esc_html__( 'Agent Field Color', 'talkino' ),
+			array( $this, 'agent_field_color_section_callback' ),
+			'talkino_styles_page'
+		);
+
 		// Register ordering section in the talkino ordering page.
 		add_settings_section(
 			'talkino_ordering_section',
@@ -404,8 +474,16 @@ class Talkino_Settings {
 		// Register display section in the talkino page.
 		add_settings_section(
 			'talkino_display_section',
-			esc_html__( 'Display', 'talkino' ),
+			esc_html__( 'Pages Display', 'talkino' ),
 			array( $this, 'display_section_callback' ),
+			'talkino_display_page'
+		);
+
+		// Register display section in the talkino page.
+		add_settings_section(
+			'talkino_visibility_section',
+			esc_html__( 'Visibility', 'talkino' ),
+			array( $this, 'visibility_section_callback' ),
 			'talkino_display_page'
 		);
 
@@ -425,6 +503,14 @@ class Talkino_Settings {
 			'talkino_contact_form_page'
 		);
 
+		// Register credit section in the talkino credit page.
+		add_settings_section(
+			'talkino_credit_section',
+			esc_html__( 'Credit', 'talkino' ),
+			array( $this, 'credit_section_callback' ),
+			'talkino_credit_page'
+		);
+
 		// Register advanced section in the talkino advanced page.
 		add_settings_section(
 			'talkino_advanced_section',
@@ -434,6 +520,26 @@ class Talkino_Settings {
 		);
 
 		/** Settings */
+		// Register chatbox activation field.
+		register_setting(
+			'talkino_settings_page',
+			'talkino_chatbox_activation',
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => array( $this, 'sanitize_chatbox_activation' ),
+				'default'           => '',
+			)
+		);
+
+		// Add chatbox activation field.
+		add_settings_field(
+			'chatbox_activation_id',
+			esc_html__( 'Chatbox Activation Status:', 'talkino' ),
+			array( $this, 'chatbox_activation_field_callback' ),
+			'talkino_settings_page',
+			'talkino_global_online_status_section'
+		);
+
 		// Register global online status field.
 		register_setting(
 			'talkino_settings_page',
@@ -535,25 +641,6 @@ class Talkino_Settings {
 			'talkino_text_section'
 		);
 
-		// Register agent not available message option field.
-		register_setting(
-			'talkino_settings_page',
-			'talkino_agent_not_available_message',
-			array(
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_textarea_field',
-			)
-		);
-
-		// Add agent not available option field.
-		add_settings_field(
-			'agent_not_available_message_id',
-			esc_html__( 'Agent Not Available Message:', 'talkino' ),
-			array( $this, 'agent_not_available_message_field_callback' ),
-			'talkino_settings_page',
-			'talkino_text_section'
-		);
-
 		// Register offline message option field.
 		register_setting(
 			'talkino_settings_page',
@@ -651,59 +738,21 @@ class Talkino_Settings {
 			'talkino_styles_section'
 		);
 
-		// Register load font awesome deferred option field.
+		// Register chatbox animation option field.
 		register_setting(
 			'talkino_styles_page',
-			'talkino_load_font_awesome_deferred',
+			'talkino_chatbox_animation',
 			array(
 				'type'              => 'string',
-				'sanitize_callback' => array( $this, 'sanitize_load_font_awesome_deferred' ),
+				'sanitize_callback' => array( $this, 'sanitize_chatbox_animation' ),
 			)
 		);
 
-		// Add load font awesome deferred option field.
+		// Add chatbox animation option field.
 		add_settings_field(
-			'load_font_awesome_deferred_id',
-			esc_html__( 'Load Font Awesome Deferred:', 'talkino' ),
-			array( $this, 'load_font_awesome_deferred_field_callback' ),
-			'talkino_styles_page',
-			'talkino_styles_section'
-		);
-
-		// Register show on desktop option field.
-		register_setting(
-			'talkino_styles_page',
-			'talkino_show_on_desktop',
-			array(
-				'type'              => 'string',
-				'sanitize_callback' => array( $this, 'sanitize_show_on_desktop' ),
-			)
-		);
-
-		// Add show on desktop option field.
-		add_settings_field(
-			'show_on_desktop_id',
-			esc_html__( 'Show on Desktop:', 'talkino' ),
-			array( $this, 'show_on_desktop_field_callback' ),
-			'talkino_styles_page',
-			'talkino_styles_section'
-		);
-
-		// Register show on mobile option field.
-		register_setting(
-			'talkino_styles_page',
-			'talkino_show_on_mobile',
-			array(
-				'type'              => 'string',
-				'sanitize_callback' => array( $this, 'sanitize_show_on_mobile' ),
-			)
-		);
-
-		// Add show on mobile option field.
-		add_settings_field(
-			'show_on_mobile_id',
-			esc_html__( 'Show on Mobile:', 'talkino' ),
-			array( $this, 'show_on_mobile_field_callback' ),
+			'talkino_chatbox_animation_id',
+			esc_html__( 'Chatbox Animation:', 'talkino' ),
+			array( $this, 'chatbox_animation_field_callback' ),
 			'talkino_styles_page',
 			'talkino_styles_section'
 		);
@@ -728,6 +777,35 @@ class Talkino_Settings {
 			'talkino_styles_section'
 		);
 
+		// Register chatbox z-index field.
+		register_setting(
+			'talkino_styles_page',
+			'talkino_chatbox_z_index',
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => array( $this, 'sanitize_chatbox_z_index' ),
+				'default'           => '',
+			)
+		);
+
+		// Add chatbox z-index field.
+		add_settings_field(
+			'chatbox_z_index_id',
+			esc_html__( 'Chatbox z-index:', 'talkino' ),
+			array( $this, 'chatbox_z_index_field_callback' ),
+			'talkino_styles_page',
+			'talkino_styles_section'
+		);
+
+		// Add template color option field.
+		add_settings_field(
+			'talkino_template_color_id',
+			esc_html__( 'Template Color:', 'talkino' ),
+			array( $this, 'template_color_field_callback' ),
+			'talkino_styles_page',
+			'talkino_template_section'
+		);
+
 		// Register chatbox theme color option field for online status.
 		register_setting(
 			'talkino_styles_page',
@@ -743,7 +821,25 @@ class Talkino_Settings {
 			esc_html__( 'Theme Color for Online Status:', 'talkino' ),
 			array( $this, 'chatbox_online_theme_color_field_callback' ),
 			'talkino_styles_page',
-			'talkino_styles_section'
+			'talkino_chatbox_color_section'
+		);
+
+		// Register chatbox icon color option field for online status.
+		register_setting(
+			'talkino_styles_page',
+			'talkino_chatbox_online_icon_color',
+			array(
+				'sanitize_callback' => 'sanitize_hex_color',
+			)
+		);
+
+		// Add chatbox icon color option field for online status.
+		add_settings_field(
+			'talkino_chatbox_online_icon_color_id',
+			esc_html__( 'Icon Color for Online Status:', 'talkino' ),
+			array( $this, 'chatbox_online_icon_color_field_callback' ),
+			'talkino_styles_page',
+			'talkino_chatbox_color_section'
 		);
 
 		// Register chatbox theme color option field for away status.
@@ -761,7 +857,25 @@ class Talkino_Settings {
 			esc_html__( 'Theme Color for Away Status:', 'talkino' ),
 			array( $this, 'chatbox_away_theme_color_field_callback' ),
 			'talkino_styles_page',
-			'talkino_styles_section'
+			'talkino_chatbox_color_section'
+		);
+
+		// Register chatbox icon color option field for away status.
+		register_setting(
+			'talkino_styles_page',
+			'talkino_chatbox_away_icon_color',
+			array(
+				'sanitize_callback' => 'sanitize_hex_color',
+			)
+		);
+
+		// Add chatbox icon color option field for away status.
+		add_settings_field(
+			'talkino_chatbox_away_icon_color_id',
+			esc_html__( 'Icon Color for Away Status:', 'talkino' ),
+			array( $this, 'chatbox_away_icon_color_field_callback' ),
+			'talkino_styles_page',
+			'talkino_chatbox_color_section'
 		);
 
 		// Register chatbox theme color option field for offline status.
@@ -779,7 +893,25 @@ class Talkino_Settings {
 			esc_html__( 'Theme Color for Offline Status:', 'talkino' ),
 			array( $this, 'chatbox_offline_theme_color_field_callback' ),
 			'talkino_styles_page',
-			'talkino_styles_section'
+			'talkino_chatbox_color_section'
+		);
+
+		// Register chatbox icon color option field for offline status.
+		register_setting(
+			'talkino_styles_page',
+			'talkino_chatbox_offline_icon_color',
+			array(
+				'sanitize_callback' => 'sanitize_hex_color',
+			)
+		);
+
+		// Add chatbox icon color option field for offline status.
+		add_settings_field(
+			'talkino_chatbox_offline_icon_color_id',
+			esc_html__( 'Icon Color for Offline Status:', 'talkino' ),
+			array( $this, 'chatbox_offline_icon_color_field_callback' ),
+			'talkino_styles_page',
+			'talkino_chatbox_color_section'
 		);
 
 		// Register chatbox background color option field.
@@ -794,10 +926,10 @@ class Talkino_Settings {
 		// Add chatbox background color option field.
 		add_settings_field(
 			'talkino_chatbox_background_color_id',
-			esc_html__( 'Background Color for Chatbox:', 'talkino' ),
+			esc_html__( 'Background Color:', 'talkino' ),
 			array( $this, 'chatbox_background_color_field_callback' ),
 			'talkino_styles_page',
-			'talkino_styles_section'
+			'talkino_chatbox_color_section'
 		);
 
 		// Register chatbox title color option field.
@@ -812,10 +944,10 @@ class Talkino_Settings {
 		// Add chatbox title color option field.
 		add_settings_field(
 			'talkino_chatbox_title_color_id',
-			esc_html__( 'Title Color for Chatbox:', 'talkino' ),
+			esc_html__( 'Title Color:', 'talkino' ),
 			array( $this, 'chatbox_title_color_field_callback' ),
 			'talkino_styles_page',
-			'talkino_styles_section'
+			'talkino_chatbox_color_section'
 		);
 
 		// Register chatbox subtitle color option field.
@@ -830,10 +962,140 @@ class Talkino_Settings {
 		// Add chatbox subtitle color option field.
 		add_settings_field(
 			'talkino_chatbox_subtitle_color_id',
-			esc_html__( 'Subtitle Color for Chatbox:', 'talkino' ),
+			esc_html__( 'Subtitle Color:', 'talkino' ),
 			array( $this, 'chatbox_subtitle_color_field_callback' ),
 			'talkino_styles_page',
-			'talkino_styles_section'
+			'talkino_chatbox_color_section'
+		);
+
+		if ( is_plugin_active( 'talkino-bundle/talkino-bundle.php' ) ) {
+
+			// Register button color option field.
+			register_setting(
+				'talkino_styles_page',
+				'talkino_chatbox_button_color',
+				array(
+					'sanitize_callback' => 'sanitize_hex_color',
+				)
+			);
+
+			// Add button color option field.
+			add_settings_field(
+				'talkino_chatbox_button_color_id',
+				esc_html__( 'Button Color:', 'talkino' ),
+				array( $this, 'chatbox_button_color_field_callback' ),
+				'talkino_styles_page',
+				'talkino_chatbox_color_section'
+			);
+
+			// Register button color option field.
+			register_setting(
+				'talkino_styles_page',
+				'talkino_chatbox_button_text_color',
+				array(
+					'sanitize_callback' => 'sanitize_hex_color',
+				)
+			);
+
+			// Add button color option field.
+			add_settings_field(
+				'talkino_chatbox_button_text_color_id',
+				esc_html__( 'Button Text Color:', 'talkino' ),
+				array( $this, 'chatbox_button_text_color_field_callback' ),
+				'talkino_styles_page',
+				'talkino_chatbox_color_section'
+			);
+
+		}
+
+		// Register agent field background color option field.
+		register_setting(
+			'talkino_styles_page',
+			'talkino_agent_field_background_color',
+			array(
+				'sanitize_callback' => 'sanitize_hex_color',
+			)
+		);
+
+		// Add agent field background color option field.
+		add_settings_field(
+			'talkino_agent_field_background_color_id',
+			esc_html__( 'Field Background Color:', 'talkino' ),
+			array( $this, 'agent_field_background_color_field_callback' ),
+			'talkino_styles_page',
+			'talkino_agent_field_color_section'
+		);
+
+		// Register agent field hover background color option field.
+		register_setting(
+			'talkino_styles_page',
+			'talkino_agent_field_hover_background_color',
+			array(
+				'sanitize_callback' => 'sanitize_hex_color',
+			)
+		);
+
+		// Add agent field hover background color option field.
+		add_settings_field(
+			'talkino_agent_field_hover_background_color_id',
+			esc_html__( 'Field Hover Background Color:', 'talkino' ),
+			array( $this, 'agent_field_hover_background_color_field_callback' ),
+			'talkino_styles_page',
+			'talkino_agent_field_color_section'
+		);
+
+		// Register agent name text color option field.
+		register_setting(
+			'talkino_styles_page',
+			'talkino_agent_name_text_color',
+			array(
+				'sanitize_callback' => 'sanitize_hex_color',
+			)
+		);
+
+		// Add agent name text color option field.
+		add_settings_field(
+			'talkino_agent_name_text_color_id',
+			esc_html__( 'Name Text Color:', 'talkino' ),
+			array( $this, 'agent_name_text_color_field_callback' ),
+			'talkino_styles_page',
+			'talkino_agent_field_color_section'
+		);
+
+		// Register agent job title text color option field.
+		register_setting(
+			'talkino_styles_page',
+			'talkino_agent_job_title_text_color',
+			array(
+				'sanitize_callback' => 'sanitize_hex_color',
+			)
+		);
+
+		// Add agent job title text color option field.
+		add_settings_field(
+			'talkino_agent_job_title_text_color_id',
+			esc_html__( 'Job Title Text Color:', 'talkino' ),
+			array( $this, 'agent_job_title_text_color_field_callback' ),
+			'talkino_styles_page',
+			'talkino_agent_field_color_section'
+		);
+
+		// Register agent channel text color option field.
+		register_setting(
+			'talkino_styles_page',
+			'talkino_agent_channel_text_color',
+			array(
+				'sanitize_callback' => 'sanitize_hex_color',
+			)
+		);
+
+		// Add agent channel text color option field.
+		add_settings_field(
+			'talkino_agent_channel_text_color_id',
+			esc_html__( 'Channel Text Color:', 'talkino' ),
+			array( $this, 'agent_channel_text_color_field_callback' ),
+			'talkino_styles_page',
+			'talkino_agent_field_color_section'
 		);
 
 		/** Ordering */
@@ -912,6 +1174,25 @@ class Talkino_Settings {
 			'talkino_display_section'
 		);
 
+		// Register show on 404 option field.
+		register_setting(
+			'talkino_display_page',
+			'talkino_show_on_404',
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => array( $this, 'sanitize_show_on_404' ),
+			)
+		);
+
+		// Add show on 404 option field.
+		add_settings_field(
+			'show_on_404_id',
+			esc_html__( 'Show on 404 Page:', 'talkino' ),
+			array( $this, 'show_on_404_field_callback' ),
+			'talkino_display_page',
+			'talkino_display_section'
+		);
+
 		// Check whether woocommerce is activated.
 		if ( $talkino_utility->is_woocommerce_activated() ) {
 
@@ -934,6 +1215,64 @@ class Talkino_Settings {
 				'talkino_display_section'
 			);
 		}
+
+		// Register show on desktop option field.
+		register_setting(
+			'talkino_display_page',
+			'talkino_show_on_desktop',
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => array( $this, 'sanitize_show_on_desktop' ),
+			)
+		);
+
+		// Add show on desktop option field.
+		add_settings_field(
+			'show_on_desktop_id',
+			esc_html__( 'Show on Desktop:', 'talkino' ),
+			array( $this, 'show_on_desktop_field_callback' ),
+			'talkino_display_page',
+			'talkino_visibility_section'
+		);
+
+		// Register show on mobile option field.
+		register_setting(
+			'talkino_display_page',
+			'talkino_show_on_mobile',
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => array( $this, 'sanitize_show_on_mobile' ),
+			)
+		);
+
+		// Add show on mobile option field.
+		add_settings_field(
+			'show_on_mobile_id',
+			esc_html__( 'Show on Mobile:', 'talkino' ),
+			array( $this, 'show_on_mobile_field_callback' ),
+			'talkino_display_page',
+			'talkino_visibility_section'
+		);
+
+		// Register user_visibility option field.
+		register_setting(
+			'talkino_display_page',
+			'talkino_user_visibility',
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => array( $this, 'sanitize_user_visibility' ),
+			)
+		);
+
+		// Add user_visibility option field.
+		add_settings_field(
+			'user_visibility_id',
+			esc_html__( 'User Visibility:', 'talkino' ),
+			array( $this, 'user_visibility_field_callback' ),
+			'talkino_display_page',
+			'talkino_visibility_section'
+		);
+
 
 		/** Contact Form */
 		// Register contact form status option field.
@@ -1145,6 +1484,26 @@ class Talkino_Settings {
 			'talkino_google_recaptcha_section'
 		);
 
+		/** Credit */
+		// Register credit option field.
+		register_setting(
+			'talkino_credit_page',
+			'talkino_credit',
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => array( $this, 'sanitize_credit' ),
+			)
+		);
+
+		// Add credit option field.
+		add_settings_field(
+			'credit_id',
+			esc_html__( 'Enable credit display:', 'talkino' ),
+			array( $this, 'credit_field_callback' ),
+			'talkino_credit_page',
+			'talkino_credit_section'
+		);
+
 		/** Advanced */
 		// Register reset settings status option field.
 		register_setting(
@@ -1230,6 +1589,48 @@ class Talkino_Settings {
 	}
 
 	/**
+	 * Callback function to render the template section.
+	 *
+	 * @since    2.0.0
+	 * @param    array $args    The arguments of template section.
+	 */
+	public function template_section_callback( $args ) {
+
+		?>
+		<p id="<?php echo esc_attr( $args['id'] ); ?>"><?php esc_html_e( 'Options of template for the chatbox.', 'talkino' ); ?></p>
+		<?php
+
+	}
+
+	/**
+	 * Callback function to render the chatbox color section.
+	 *
+	 * @since    2.0.0
+	 * @param    array $args    The arguments of chatbox color section.
+	 */
+	public function color_section_callback( $args ) {
+
+		?>
+		<p id="<?php echo esc_attr( $args['id'] ); ?>"><?php esc_html_e( 'Customize the colors of the chatbox.', 'talkino' ); ?></p>
+		<?php
+
+	}
+
+	/**
+	 * Callback function to render the agent field color section.
+	 *
+	 * @since    2.0.0
+	 * @param    array $args    The arguments of agent field color section.
+	 */
+	public function agent_field_color_section_callback( $args ) {
+
+		?>
+		<p id="<?php echo esc_attr( $args['id'] ); ?>"><?php esc_html_e( 'Customize the colors of the agent field.', 'talkino' ); ?></p>
+		<?php
+
+	}
+
+	/**
 	 * Callback function to render the ordering section.
 	 *
 	 * @since    1.0.0
@@ -1253,6 +1654,20 @@ class Talkino_Settings {
 
 		?>
 		<p id="<?php echo esc_attr( $args['id'] ); ?>"><?php esc_html_e( 'Manage the pages, post, search and WooCommerce pages to display or hide chatbox.', 'talkino' ); ?></p>
+		<?php
+
+	}
+
+	/**
+	 * Callback function to render the visibility section.
+	 *
+	 * @since    1.0.0
+	 * @param    array $args    The arguments of visibility section.
+	 */
+	public function visibility_section_callback( $args ) {
+
+		?>
+		<p id="<?php echo esc_attr( $args['id'] ); ?>"><?php esc_html_e( 'Manage the chatbox visibility on desktop and mobile.', 'talkino' ); ?></p>
 		<?php
 
 	}
@@ -1289,6 +1704,20 @@ class Talkino_Settings {
 	}
 
 	/**
+	 * Callback function to render the credit section.
+	 *
+	 * @since    2.0.0
+	 * @param    array $args    The arguments of credit section.
+	 */
+	public function credit_section_callback( $args ) {
+
+		?>
+		<p id="<?php echo esc_attr( $args['id'] ); ?>"><?php esc_html_e( 'The credit settings to control the option of displaying credit on the chatbox.', 'talkino' ); ?></p>
+		<?php
+
+	}
+
+	/**
 	 * Callback function to render the advanced section.
 	 *
 	 * @since    1.0.0
@@ -1304,6 +1733,47 @@ class Talkino_Settings {
 
 	/********************************* Settings *********************************/
 	/**
+	 * Callback function to render chatbox activation field.
+	 *
+	 * @since    1.0.0
+	 */
+	public function chatbox_activation_field_callback() {
+
+		$chatbox_activation_field = get_option( 'talkino_chatbox_activation' );
+
+		?>
+		<select name="talkino_chatbox_activation" class="regular-text">
+			<option value="active" <?php selected( 'active', $chatbox_activation_field ); ?>><?php esc_html_e( 'Active', 'talkino' ); ?></option>
+			<option value="inactive" <?php selected( 'inactive', $chatbox_activation_field ); ?>><?php esc_html_e( 'Inactive', 'talkino' ); ?></option>
+		</select>
+		<?php
+
+	}
+
+	/**
+	 * Sanitize function to validate the chatbox activation field.
+	 *
+	 * @since     1.0.0
+	 * @param     string $chatbox_activation    The chatbox_activation.
+	 *
+	 * @return    string    The validated value of chatbox_activation.
+	 */
+	public function sanitize_chatbox_activation( $chatbox_activation ) {
+
+		if ( 'active' !== $chatbox_activation && 'inactive' !== $chatbox_activation ) {
+
+			$chatbox_activation = 'active';
+
+			// Notify the user on invalid input.
+			add_settings_error( 'talkino_chatbox_activation', 'invalid_chatbox_activation_value', esc_html__( 'Oops, you have inserted invalid input of chatbox activation field!', 'talkino' ), 'error' );
+
+		}
+
+		return $chatbox_activation;
+
+	}
+
+	/**
 	 * Callback function to render global online status field.
 	 *
 	 * @since    1.0.0
@@ -1314,9 +1784,9 @@ class Talkino_Settings {
 
 		?>
 		<select name="talkino_global_online_status" class="regular-text">
-			<option value="Online" <?php selected( 'Online', $global_online_status_field ); ?>><?php esc_html_e( 'Online', 'talkino' ); ?></option>
-			<option value="Away" <?php selected( 'Away', $global_online_status_field ); ?>><?php esc_html_e( 'Away', 'talkino' ); ?></option>
-			<option value="Offline" <?php selected( 'Offline', $global_online_status_field ); ?>><?php esc_html_e( 'Offline', 'talkino' ); ?></option>
+			<option value="online" <?php selected( 'online', $global_online_status_field ); ?>><?php esc_html_e( 'Online', 'talkino' ); ?></option>
+			<option value="away" <?php selected( 'away', $global_online_status_field ); ?>><?php esc_html_e( 'Away', 'talkino' ); ?></option>
+			<option value="offline" <?php selected( 'offline', $global_online_status_field ); ?>><?php esc_html_e( 'Offline', 'talkino' ); ?></option>
 		</select>
 		<?php
 
@@ -1332,9 +1802,9 @@ class Talkino_Settings {
 	 */
 	public function sanitize_global_online_status( $global_online_status ) {
 
-		if ( 'Online' !== $global_online_status && 'Away' !== $global_online_status && 'Offline' !== $global_online_status ) {
+		if ( 'online' !== $global_online_status && 'away' !== $global_online_status && 'offline' !== $global_online_status ) {
 
-			$global_online_status = 'Online';
+			$global_online_status = 'online';
 
 			// Notify the user on invalid input.
 			add_settings_error( 'talkino_global_online_status', 'invalid_global_online_status_value', esc_html__( 'Oops, you have inserted invalid input of global online status field!', 'talkino' ), 'error' );
@@ -1805,20 +2275,6 @@ class Talkino_Settings {
 	}
 
 	/**
-	 * Callback function to render text area field of agent not available message.
-	 *
-	 * @since    1.0.0
-	 */
-	public function agent_not_available_message_field_callback() {
-
-		$agent_not_available_message = get_option( 'talkino_agent_not_available_message' );
-		?>
-		<textarea name="talkino_agent_not_available_message" class="large-text" maxlength="100" rows="2"><?php echo isset( $agent_not_available_message ) ? esc_textarea( $agent_not_available_message ) : ''; ?></textarea>
-		<?php
-
-	}
-
-	/**
 	 * Callback function to render text area field of offline message.
 	 *
 	 * @since    1.0.0
@@ -1961,153 +2417,70 @@ class Talkino_Settings {
 		$chatbox_icon_field = get_option( 'talkino_chatbox_icon' );
 
 		?>
-		<input type="hidden" id="talkino-chatbox-icon" type="text" name="talkino_chatbox_icon" placeholder="Select icon" data-fa-browser value="<?php echo isset( $chatbox_icon_field ) ? esc_attr( $chatbox_icon_field ) : 'fa fa-comment'; ?>" />
 		<span id="talkino-icon-container">
-			<i id="talkino-icon-preview" class="<?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> fa-2xl talkino"></i>
+			<i id="talkino-icon-preview" class="dashicons <?php echo esc_html( $chatbox_icon_field ); ?> talkino"></i>
 		</span>
-		<i><?php esc_html_e( 'Please click on the icon to select the Font Awesome icon of chatbox.', 'talkino' ); ?></i>
+
+		<input class="regular-text" type="hidden" id="talkino_dashicons_picker" name="talkino_chatbox_icon" readonly value="<?php echo isset( $chatbox_icon_field ) ? esc_attr( $chatbox_icon_field ) : 'dashicons-format-chat'; ?>"/>
+		<input type="button" data-target="#talkino_dashicons_picker" class="button dashicons-picker" value="Choose Icon" />	
 		<?php
 
 	}
 
 	/**
-	 * Callback function to load font awesome deferred field.
+	 * Callback function to render chatbox animation field.
 	 *
-	 * @since    1.1.6
+	 * @since    1.0.0
 	 */
-	public function load_font_awesome_deferred_field_callback() {
+	public function chatbox_animation_field_callback() {
 
-		$load_font_awesome_deferred    = get_option( 'talkino_load_font_awesome_deferred' );
-		$is_load_font_awesome_deferred = ( ! empty( $load_font_awesome_deferred ) && 'on' === $load_font_awesome_deferred ) ? 'checked' : '';
-
+		$chatbox_animation_field = get_option( 'talkino_chatbox_animation' );
 		?>
-		<input name="talkino_load_font_awesome_deferred" type="hidden" value='off'/>
-		<input name="talkino_load_font_awesome_deferred" type="checkbox" <?php echo esc_attr( $is_load_font_awesome_deferred ); ?> value='on' /> <?php esc_html_e( 'Enable Talkino to load the latest version of Font Awesome at highest priority.', 'talkino' ); ?>
 		<p>
-			<i><?php esc_html_e( 'Recommended to enable this feature to load the latest version of Font Awesome at higest priority or turn it off if the latest version of Font Awesome affects your theme.', 'talkino' ); ?></i>
+			<label for="no">
+				<input type="radio" name="talkino_chatbox_animation" value="no" <?php checked( 'no', $chatbox_animation_field ); ?>/> <?php esc_html_e( 'No animation', 'talkino' ); ?>
+			</label>
+		</p>
+		<p>
+			<label for="fadein">
+				<input type="radio" name="talkino_chatbox_animation" value="fadein" <?php checked( 'fadein', $chatbox_animation_field ); ?>/> <?php esc_html_e( 'Fade in', 'talkino' ); ?> 
+			</label>
+		</p>
+		<p>
+			<label for="slideup">
+				<input type="radio" name="talkino_chatbox_animation" value="slideup" <?php checked( 'slideup', $chatbox_animation_field ); ?>/> <?php esc_html_e( 'Slide up', 'talkino' ); ?> 
+			</label>
 		</p>
 		<?php
 
 	}
 
 	/**
-	 * Sanitize function to validate the load font awesome deferred field.
-	 *
-	 * @since     1.1.6
-	 * @param     string $load_font_awesome_deferred    The load font awesome deferred value.
-	 *
-	 * @return    string    The validated value of load font awesome deferred.
-	 */
-	public function sanitize_load_font_awesome_deferred( $load_font_awesome_deferred ) {
-
-		// Sanitize the checkbox.
-		if ( ! empty( $load_font_awesome_deferred ) ) {
-			if ( 'on' === $load_font_awesome_deferred || 'off' === $load_font_awesome_deferred ) {
-				$load_font_awesome_deferred = $load_font_awesome_deferred;
-
-			} else {
-
-				$load_font_awesome_deferred = 'on';
-
-				// Notify the user on invalid input.
-				add_settings_error( 'talkino_load_font_awesome_deferred', 'invalid_load_font_awesome_deferred_value', esc_html__( 'Oops, you have inserted invalid input of load font awesome deferred field!', 'talkino' ), 'error' );
-
-			}
-		}
-
-		return $load_font_awesome_deferred;
-
-	}
-
-	/**
-	 * Callback function to render show on desktop field.
-	 *
-	 * @since    1.0.0
-	 */
-	public function show_on_desktop_field_callback() {
-
-		$show_on_desktop_field      = get_option( 'talkino_show_on_desktop' );
-		$is_show_on_desktop_checked = ( ! empty( $show_on_desktop_field ) && 'on' === $show_on_desktop_field ) ? 'checked' : '';
-
-		?>
-		<input name="talkino_show_on_desktop" type="hidden" value='off'/>
-		<input name="talkino_show_on_desktop" type="checkbox" <?php echo esc_attr( $is_show_on_desktop_checked ); ?> value='on' /> <?php esc_html_e( 'Enable Talkino chatbox to show on desktop.', 'talkino' ); ?>
-		<?php
-
-	}
-
-	/**
-	 * Sanitize function to validate the show on desktop field.
+	 * Sanitize function to validate the chatbox animation field.
 	 *
 	 * @since     1.0.0
-	 * @param     string $show_on_desktop    The show on desktop value.
+	 * @param     string $chatbox_animation    The chatbox animation.
 	 *
-	 * @return    string    The validated value of show on desktop.
+	 * @return    string    The validated value of chatbox animation.
 	 */
-	public function sanitize_show_on_desktop( $show_on_desktop ) {
+	public function sanitize_chatbox_animation( $chatbox_animation_field ) {
 
-		// Sanitize the checkbox.
-		if ( ! empty( $show_on_desktop ) ) {
-			if ( 'on' === $show_on_desktop || 'off' === $show_on_desktop ) {
-				$show_on_desktop = $show_on_desktop;
+		// Sanitize the radio field.
+		if ( ! empty( $chatbox_animation_field ) ) {
+			if ( 'no' === $chatbox_animation_field || 'fadein' === $chatbox_animation_field || 'slideup' === $chatbox_animation_field ) {
+				$chatbox_animation_field = $chatbox_animation_field;
 
 			} else {
 
-				$show_on_desktop = 'off';
+				$chatbox_animation_field = 'fadein';
 
 				// Notify the user on invalid input.
-				add_settings_error( 'talkino_show_on_desktop', 'invalid_show_on_desktop_value', esc_html__( 'Oops, you have inserted invalid input of show on desktop field!', 'talkino' ), 'error' );
+				add_settings_error( 'talkino_chatbox_animation', 'invalid_chatbox_animation_value', esc_html__( 'Oops, you have inserted invalid input of chatbox animation field!', 'talkino' ), 'error' );
 
 			}
 		}
 
-		return $show_on_desktop;
-
-	}
-
-	/**
-	 * Callback function to render show on mobile field.
-	 *
-	 * @since    1.0.0
-	 */
-	public function show_on_mobile_field_callback() {
-
-		$show_on_mobile_field      = get_option( 'talkino_show_on_mobile' );
-		$is_show_on_mobile_checked = ( ! empty( $show_on_mobile_field ) && 'on' === $show_on_mobile_field ) ? 'checked' : '';
-
-		?>
-		<input name="talkino_show_on_mobile" type="hidden" value='off'/>
-		<input name="talkino_show_on_mobile" type="checkbox" <?php echo esc_attr( $is_show_on_mobile_checked ); ?> value='on' /> <?php esc_html_e( 'Enable Talkino chatbox to show on mobile.', 'talkino' ); ?>
-		<?php
-
-	}
-
-	/**
-	 * Sanitize function to validate the show on mobile field.
-	 *
-	 * @since     1.0.0
-	 * @param     string $show_on_mobile    The show on mobile value.
-	 *
-	 * @return    string    The validated value of show on mobile.
-	 */
-	public function sanitize_show_on_mobile( $show_on_mobile ) {
-
-		// Sanitize the checkbox.
-		if ( ! empty( $show_on_mobile ) ) {
-			if ( 'on' === $show_on_mobile || 'off' === $show_on_mobile ) {
-				$show_on_mobile = $show_on_mobile;
-
-			} else {
-
-				$show_on_mobile = 'off';
-
-				// Notify the user on invalid input.
-				add_settings_error( 'talkino_show_on_mobile', 'invalid_show_on_mobile_value', esc_html__( 'Oops, you have inserted invalid input of show on mobile field!', 'talkino' ), 'error' );
-
-			}
-		}
-
-		return $show_on_mobile;
+		return $chatbox_animation_field;
 
 	}
 
@@ -2153,6 +2526,68 @@ class Talkino_Settings {
 	}
 
 	/**
+	 * Callback function to render chatbox z-index field.
+	 *
+	 * @since    2.0.0
+	 */
+	public function chatbox_z_index_field_callback() {
+
+		$chatbox_z_index_field = get_option( 'talkino_chatbox_z_index' );
+
+		?>
+		<input type="text" name="talkino_chatbox_z_index" class="regular-text" value="<?php echo isset( $chatbox_z_index_field ) ? esc_attr( $chatbox_z_index_field ) : '9999999'; ?>" />
+		<p><?php esc_html_e( 'The z-index property specifies the stack order of an element (which element should be placed in front of, or behind the others). Increase the z-index so that the chatbox will be displayed in front of other elements.', 'talkino' ); ?></p>
+		<?php
+
+	}
+
+	/**
+	 * Sanitize function to validate the chatbox z-index field.
+	 *
+	 * @since     2.0.0
+	 * @param     string $z_index    The chatbox z-index.
+	 *
+	 * @return    string    The validated value of chatbox z-index.
+	 */
+	public function sanitize_chatbox_z_index( $z_index ) {
+
+		if ( ! preg_match('/^[0-9+-]*$/', $z_index) ) {
+
+			$z_index = '9999999';
+
+			// Notify the user on invalid input.
+			add_settings_error( 'talkino_chatbox_z_index', 'invalid_chatbox_z_index_value', esc_html__( 'Oops, you have inserted invalid input of chatbox z-index field!', 'talkino' ), 'error' );
+
+		}
+
+		return $z_index;
+
+	}
+
+	/**
+	 * Callback function to render template color.
+	 *
+	 * @since    2.0.0
+	 */
+	public function template_color_field_callback() {
+
+		?>
+		<button type="button" id="talkino_template_color_default" style="background-color: #1e73be; border-color: #1e73be;" class="button button-primary" name="talkino_template_color_default" /><?php esc_html_e( 'Default', 'talkino' ); ?></button>
+		<button type="button" id="talkino_template_color_sky" style="background-color: #00c3ff; border-color: #00c3ff; margin-left: 4px;" class="button button-primary" name="talkino_template_color_sky" /><?php esc_html_e( 'Sky', 'talkino' ); ?></button>
+		<button type="button" id="talkino_template_color_fashion" style="background-color: #6e3abb; border-color: #6e3abb; margin-left: 4px;" class="button button-primary" name="talkino_template_color_fashion" /><?php esc_html_e( 'Fashion', 'talkino' ); ?></button>
+		<button type="button" id="talkino_template_color_passion" style="background-color: #dd3333; border-color: #dd3333; margin-left: 4px;" class="button button-primary" name="talkino_template_color_passion" /><?php esc_html_e( 'Passion', 'talkino' ); ?></button>
+		<button type="button" id="talkino_template_color_confidence" style="background-color: #ff8100; border-color: #ff8100; margin-left: 4px;" class="button button-primary" name="talkino_template_color_confidence" /><?php esc_html_e( 'Confidence', 'talkino' ); ?></button>
+		<button type="button" id="talkino_template_color_sunshine" style="background-color: #ffb300; border-color: #ffb300; margin-left: 4px;" class="button button-primary" name="talkino_template_color_sunshine" /><?php esc_html_e( 'Sunshine', 'talkino' ); ?></button>
+		<button type="button" id="talkino_template_color_forest" style="background-color: #185121; border-color: #185121; margin-left: 4px;" class="button button-primary" name="talkino_template_color_forest" /><?php esc_html_e( 'Forest', 'talkino' ); ?></button>
+		<button type="button" id="talkino_template_color_mint" style="background-color: #7ecc7e; border-color: #7ecc7e; margin-left: 4px;" class="button button-primary" name="talkino_template_color_mint" /><?php esc_html_e( 'Mint', 'talkino' ); ?></button>
+		<button type="button" id="talkino_template_color_coffee" style="background-color: #863d26; border-color: #863d26; margin-left: 4px;" class="button button-primary" name="talkino_template_color_coffee" /><?php esc_html_e( 'Coffee', 'talkino' ); ?></button>
+		<button type="button" id="talkino_template_color_midnight" style="background-color: #2b2827; border-color: #2b2827; margin-left: 4px;" class="button button-primary" name="talkino_template_color_midnight" /><?php esc_html_e( 'Midnight', 'talkino' ); ?></button>
+		<p><?php esc_html_e( 'Select the color template to change the chatbox layout or you can customize your own color template with below settings.', 'talkino' ); ?></p>
+		<?php
+
+	}
+
+	/**
 	 * Callback function to render chatbox theme color for online status.
 	 *
 	 * @since    1.0.0
@@ -2162,7 +2597,22 @@ class Talkino_Settings {
 		$chatbox_online_theme_color_field = get_option( 'talkino_chatbox_online_theme_color' );
 
 		?>
-		<input type="text" name="talkino_chatbox_online_theme_color" class="color-picker" value="<?php echo isset( $chatbox_online_theme_color_field ) ? esc_attr( $chatbox_online_theme_color_field ) : '#1e73be'; ?>"/>
+		<input type="text" id="talkino_chatbox_online_theme_color" name="talkino_chatbox_online_theme_color" class="color-picker" value="<?php echo isset( $chatbox_online_theme_color_field ) ? esc_attr( $chatbox_online_theme_color_field ) : '#1e73be'; ?>"/>
+		<?php
+
+	}
+
+	/**
+	 * Callback function to render chatbox icon color for online status.
+	 *
+	 * @since    2.0.0
+	 */
+	public function chatbox_online_icon_color_field_callback() {
+
+		$chatbox_online_icon_color_field = get_option( 'talkino_chatbox_online_icon_color' );
+
+		?>
+		<input type="text" id="talkino_chatbox_online_icon_color" name="talkino_chatbox_online_icon_color" class="color-picker" value="<?php echo isset( $chatbox_online_icon_color_field ) ? esc_attr( $chatbox_online_icon_color_field ) : '#fff'; ?>"/>
 		<?php
 
 	}
@@ -2177,7 +2627,22 @@ class Talkino_Settings {
 		$chatbox_away_theme_color_field = get_option( 'talkino_chatbox_away_theme_color' );
 
 		?>
-		<input type="text" name="talkino_chatbox_away_theme_color" class="color-picker" value="<?php echo isset( $chatbox_away_theme_color_field ) ? esc_attr( $chatbox_away_theme_color_field ) : '#ffa500'; ?>"/>
+		<input type="text" id="talkino_chatbox_away_theme_color" name="talkino_chatbox_away_theme_color" class="color-picker" value="<?php echo isset( $chatbox_away_theme_color_field ) ? esc_attr( $chatbox_away_theme_color_field ) : '#ffa500'; ?>"/>
+		<?php
+
+	}
+
+	/**
+	 * Callback function to render chatbox icon color for away status.
+	 *
+	 * @since    2.0.0
+	 */
+	public function chatbox_away_icon_color_field_callback() {
+
+		$chatbox_away_icon_color_field = get_option( 'talkino_chatbox_away_icon_color' );
+
+		?>
+		<input type="text" id="talkino_chatbox_away_icon_color" name="talkino_chatbox_away_icon_color" class="color-picker" value="<?php echo isset( $chatbox_away_icon_color_field ) ? esc_attr( $chatbox_away_icon_color_field ) : '#fff'; ?>"/>
 		<?php
 
 	}
@@ -2192,7 +2657,22 @@ class Talkino_Settings {
 		$chatbox_offline_theme_color_field = get_option( 'talkino_chatbox_offline_theme_color' );
 
 		?>
-		<input type="text" name="talkino_chatbox_offline_theme_color" class="color-picker" value="<?php echo isset( $chatbox_offline_theme_color_field ) ? esc_attr( $chatbox_offline_theme_color_field ) : '#aec6cf'; ?>"/>
+		<input type="text" id="talkino_chatbox_offline_theme_color" name="talkino_chatbox_offline_theme_color" class="color-picker" value="<?php echo isset( $chatbox_offline_theme_color_field ) ? esc_attr( $chatbox_offline_theme_color_field ) : '#aec6cf'; ?>"/>
+		<?php
+
+	}
+
+	/**
+	 * Callback function to render chatbox icon color for offline status.
+	 *
+	 * @since    1.0.0
+	 */
+	public function chatbox_offline_icon_color_field_callback() {
+
+		$chatbox_offline_icon_color_field = get_option( 'talkino_chatbox_offline_icon_color' );
+
+		?>
+		<input type="text" id="talkino_chatbox_offline_icon_color" name="talkino_chatbox_offline_icon_color" class="color-picker" value="<?php echo isset( $chatbox_offline_icon_color_field ) ? esc_attr( $chatbox_offline_icon_color_field ) : '#fff'; ?>"/>
 		<?php
 
 	}
@@ -2207,7 +2687,7 @@ class Talkino_Settings {
 		$chatbox_background_color_field = get_option( 'talkino_chatbox_background_color' );
 
 		?>
-		<input type="text" name="talkino_chatbox_background_color" class="color-picker" value="<?php echo isset( $chatbox_background_color_field ) ? esc_attr( $chatbox_background_color_field ) : '#fff'; ?>"/>
+		<input type="text" id="talkino_chatbox_background_color" name="talkino_chatbox_background_color" class="color-picker" value="<?php echo isset( $chatbox_background_color_field ) ? esc_attr( $chatbox_background_color_field ) : '#f0f0f1'; ?>"/>
 		<?php
 
 	}
@@ -2222,7 +2702,7 @@ class Talkino_Settings {
 		$chatbox_title_color_field = get_option( 'talkino_chatbox_title_color' );
 
 		?>
-		<input type="text" name="talkino_chatbox_title_color" class="color-picker" value="<?php echo isset( $chatbox_title_color_field ) ? esc_attr( $chatbox_title_color_field ) : '#fff'; ?>"/>
+		<input type="text" id="talkino_chatbox_title_color" name="talkino_chatbox_title_color" class="color-picker" value="<?php echo isset( $chatbox_title_color_field ) ? esc_attr( $chatbox_title_color_field ) : '#fff'; ?>"/>
 		<?php
 
 	}
@@ -2237,7 +2717,112 @@ class Talkino_Settings {
 		$chatbox_subtitle_color_field = get_option( 'talkino_chatbox_subtitle_color' );
 
 		?>
-		<input type="text" name="talkino_chatbox_subtitle_color" class="color-picker" value="<?php echo isset( $chatbox_subtitle_color_field ) ? esc_attr( $chatbox_subtitle_color_field ) : '#000'; ?>"/>
+		<input type="text" id="talkino_chatbox_subtitle_color" name="talkino_chatbox_subtitle_color" class="color-picker" value="<?php echo isset( $chatbox_subtitle_color_field ) ? esc_attr( $chatbox_subtitle_color_field ) : '#000'; ?>"/>
+		<?php
+
+	}
+
+	/**
+	 * Callback function to render chatbox button color.
+	 *
+	 * @since    2.0.0
+	 */
+	public function chatbox_button_color_field_callback() {
+
+		$chatbox_button_color_field = get_option( 'talkino_chatbox_button_color' );
+
+		?>
+		<input type="text" id="talkino_chatbox_button_color" name="talkino_chatbox_button_color" class="color-picker" value="<?php echo isset( $chatbox_button_color_field ) ? esc_attr( $chatbox_button_color_field ) : '#727779'; ?>"/>
+		<?php
+
+	}
+
+	/**
+	 * Callback function to render chatbox button text color.
+	 *
+	 * @since    2.0.0
+	 */
+	public function chatbox_button_text_color_field_callback() {
+
+		$chatbox_button_text_color_field = get_option( 'talkino_chatbox_button_text_color' );
+
+		?>
+		<input type="text" id="talkino_chatbox_button_text_color" name="talkino_chatbox_button_text_color" class="color-picker" value="<?php echo isset( $chatbox_button_text_color_field ) ? esc_attr( $chatbox_button_text_color_field ) : '#fff'; ?>"/>
+		<?php
+
+	}
+
+	/**
+	 * Callback function to render agent field background color.
+	 *
+	 * @since    2.0.0
+	 */
+	public function agent_field_background_color_field_callback() {
+
+		$agent_field_background_color_field = get_option( 'talkino_agent_field_background_color' );
+
+		?>
+		<input type="text" id="talkino_agent_field_background_color" name="talkino_agent_field_background_color" class="color-picker" value="<?php echo isset( $agent_field_background_color_field ) ? esc_attr( $agent_field_background_color_field ) : '#fff'; ?>"/>
+		<?php
+
+	}
+
+	/**
+	 * Callback function to render agent field hover background color.
+	 *
+	 * @since    2.0.0
+	 */
+	public function agent_field_hover_background_color_field_callback() {
+
+		$agent_field_hover_background_color_field = get_option( 'talkino_agent_field_hover_background_color' );
+
+		?>
+		<input type="text" id="talkino_agent_field_hover_background_color" name="talkino_agent_field_hover_background_color" class="color-picker" value="<?php echo isset( $agent_field_hover_background_color_field ) ? esc_attr( $agent_field_hover_background_color_field ) : '#dfdfdf'; ?>"/>
+		<?php
+
+	}
+
+	/**
+	 * Callback function to render agent name text color.
+	 *
+	 * @since    2.0.0
+	 */
+	public function agent_name_text_color_field_callback() {
+
+		$agent_name_text_color_field = get_option( 'talkino_agent_name_text_color' );
+
+		?>
+		<input type="text" id="talkino_agent_name_text_color" name="talkino_agent_name_text_color" class="color-picker" value="<?php echo isset( $agent_name_text_color_field ) ? esc_attr( $agent_name_text_color_field ) : '#222'; ?>"/>
+		<?php
+
+	}
+
+	/**
+	 * Callback function to render agent job title text color.
+	 *
+	 * @since    2.0.0
+	 */
+	public function agent_job_title_text_color_field_callback() {
+
+		$agent_job_title_text_color_field = get_option( 'talkino_agent_job_title_text_color' );
+
+		?>
+		<input type="text" id="talkino_agent_job_title_text_color" name="talkino_agent_job_title_text_color" class="color-picker" value="<?php echo isset( $agent_job_title_text_color_field ) ? esc_attr( $agent_job_title_text_color_field ) : '#888'; ?>"/>
+		<?php
+
+	}
+
+	/**
+	 * Callback function to render agent channel text color.
+	 *
+	 * @since    2.0.0
+	 */
+	public function agent_channel_text_color_field_callback() {
+
+		$agent_channel_text_color_field = get_option( 'talkino_agent_channel_text_color' );
+
+		?>
+		<input type="text" id="talkino_agent_channel_text_color" name="talkino_agent_channel_text_color" class="color-picker" value="<?php echo isset( $agent_channel_text_color_field ) ? esc_attr( $agent_channel_text_color_field ) : '#888'; ?>"/>
 		<?php
 
 	}
@@ -2277,32 +2862,32 @@ class Talkino_Settings {
 
 							case 'talkino_whatsapp':
 								$chat_channel = 'WhatsApp';
-								$channel_icon = '<i class="fab fa-whatsapp fa-xl talkino"></i>';
+								$channel_icon = "<img class='talkino-ordering-icon' src='" . plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/images/whatsapp-icon.png' . "' > ";
 								break;
 
 							case 'talkino_facebook':
 								$chat_channel = 'Facebook';
-								$channel_icon = '<i class="fab fa-facebook fa-xl talkino"></i>';
+								$channel_icon = "<img class='talkino-ordering-icon' src='" . plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/images/facebook-icon.png' . "' > ";
 								break;
 
 							case 'talkino_telegram':
 								$chat_channel = 'Telegram';
-								$channel_icon = '<i class="fab fa-telegram fa-xl talkino"></i>';
+								$channel_icon = "<img class='talkino-ordering-icon' src='" . plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/images/telegram-icon.png' . "' > ";
 								break;
 
 							case 'talkino_phone':
 								$chat_channel = 'Phone';
-								$channel_icon = '<i class="fa fa-phone fa-lg talkino"></i>';
+								$channel_icon = "<img class='talkino-ordering-icon' src='" . plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/images/phone-icon.png' . "' > ";
 								break;
 
 							case 'talkino_email':
 								$chat_channel = 'Email';
-								$channel_icon = '<i class="fa fa-envelope fa-xl talkino"></i>';
+								$channel_icon = "<img class='talkino-ordering-icon' src='" . plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/images/email-icon.png' . "' > ";
 								break;
 
 							default:
 								$chat_channel = 'WhatsApp';
-								$channel_icon = '<i class="fab fa-whatsapp fa-xl talkino"></i>';
+								$channel_icon = "<img class='talkino-ordering-icon' src='" . plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/images/whatsapp-icon.png' . "' > ";
 
 						}
 
@@ -2326,7 +2911,7 @@ class Talkino_Settings {
 	 * @since    1.0.0
 	 */
 	public function talkino_update_channel_order_list() {
-		update_option( 'talkino_channel_ordering', sanitize_text_field( $_POST['order'] ) ); // phpcs:ignore
+		update_option( 'talkino_channel_ordering', sanitize_text_field( $_POST['order'] ) );
 	}
 
 	/**
@@ -2341,7 +2926,7 @@ class Talkino_Settings {
 			'post_type'      => 'talkino_agents',
 			'post_status'    => 'publish',
 			'posts_per_page' => -1,
-			'meta_key'       => 'talkino_agent_ordering', // phpcs:ignore
+			'meta_key'       => 'talkino_agent_ordering',
 			'orderby'        => 'meta_value_num',
 			'order'          => 'ASC',
 		);
@@ -2365,7 +2950,7 @@ class Talkino_Settings {
 						// Retrieve and restrict the agent name to 20 characters.
 						$name = strlen( get_the_title() ) > 20 ? substr( get_the_title(), 0, 20 ) . '...' : get_the_title();
 
-						echo "<li id='" . esc_attr( $post_id ) . "' class='talkino_lineitem'><i class='fa fa-user fa-xl talkino'></i>
+						echo "<li id='" . esc_attr( $post_id ) . "' class='talkino_lineitem'><i class='dashicons dashicons-admin-users talkino'></i>
                         " . esc_attr( $name ) . '</li>';
 
 					endwhile;
@@ -2391,7 +2976,7 @@ class Talkino_Settings {
 	 */
 	public function talkino_update_agent_order_list() {
 
-		$order   = explode( ',', sanitize_text_field( $_POST['order'] ) ); // phpcs:ignore
+		$order   = explode( ',', sanitize_text_field( $_POST['order'] ) );
 		$counter = 1;
 
 		foreach ( $order as $post_id ) {
@@ -2417,7 +3002,7 @@ class Talkino_Settings {
 		?>
 		<?php foreach ( $pages as $page ) { ?>
 			<?php
-			$is_checked      = ( ! empty( $chatbox_exclude_pages ) && in_array( $page->ID, $chatbox_exclude_pages ) ) ? 'checked' : ''; // phpcs:ignore
+			$is_checked      = ( ! empty( $chatbox_exclude_pages ) && in_array( $page->ID, $chatbox_exclude_pages ) ) ? 'checked' : '';
 			$talkino_utility = new Talkino_Utility();
 
 			// If woocommerce is active, exclude the page that is set as blog page on theme and woocommerce shop page.
@@ -2431,6 +3016,7 @@ class Talkino_Settings {
 					<?php
 
 				}
+
 			} else { // If woocommerce is not active, exclude the page that is set as blog page on theme.
 				if ( get_option( 'page_for_posts' ) !== $page->ID ) {
 
@@ -2539,6 +3125,52 @@ class Talkino_Settings {
 	}
 
 	/**
+	 * Callback function to render show on 404 field.
+	 *
+	 * @since    2.0.0
+	 */
+	public function show_on_404_field_callback() {
+
+		$show_on_404_field      = get_option( 'talkino_show_on_404' );
+		$is_show_on_404_checked = ( ! empty( $show_on_404_field ) && 'on' === $show_on_404_field ) ? 'checked' : '';
+
+		?>
+		<input name="talkino_show_on_404" type="hidden" value='off'/>
+		<input name="talkino_show_on_404" type="checkbox" <?php echo esc_attr( $is_show_on_404_checked ); ?> value='on' /> <?php esc_html_e( 'Enable Talkino chatbox to show on 404 page.', 'talkino' ); ?>
+		<?php
+
+	}
+
+	/**
+	 * Sanitize function to validate the show on 404 field.
+	 *
+	 * @since     2.0.0
+	 * @param     string $show_on_404    The show on 404 value.
+	 *
+	 * @return    string    The validated value of show on 404.
+	 */
+	public function sanitize_show_on_404( $show_on_404 ) {
+
+		// Sanitize the checkbox.
+		if ( ! empty( $show_on_404 ) ) {
+			if ( 'on' === $show_on_404 || 'off' === $show_on_404 ) {
+				$show_on_404 = $show_on_404;
+
+			} else {
+
+				$show_on_404 = 'off';
+
+				// Notify the user on invalid input.
+				add_settings_error( 'talkino_show_on_404', 'invalid_show_on_404_value', esc_html__( 'Oops, you have inserted invalid input of show on 404 page field!', 'talkino' ), 'error' );
+
+			}
+		}
+
+		return $show_on_404;
+
+	}
+
+	/**
 	 * Callback function to render show on woocommerce shop and product pages field.
 	 *
 	 * @since    1.0.0
@@ -2581,6 +3213,139 @@ class Talkino_Settings {
 		}
 
 		return $show_on_woocommerce_pages_field;
+
+	}
+
+	/**
+	 * Callback function to render show on desktop field.
+	 *
+	 * @since    1.0.0
+	 */
+	public function show_on_desktop_field_callback() {
+
+		$show_on_desktop_field      = get_option( 'talkino_show_on_desktop' );
+		$is_show_on_desktop_checked = ( ! empty( $show_on_desktop_field ) && 'on' === $show_on_desktop_field ) ? 'checked' : '';
+
+		?>
+		<input name="talkino_show_on_desktop" type="hidden" value='off'/>
+		<input name="talkino_show_on_desktop" type="checkbox" <?php echo esc_attr( $is_show_on_desktop_checked ); ?> value='on' /> <?php esc_html_e( 'Enable Talkino chatbox to show on desktop.', 'talkino' ); ?>
+		<?php
+
+	}
+
+	/**
+	 * Sanitize function to validate the show on desktop field.
+	 *
+	 * @since     1.0.0
+	 * @param     string $show_on_desktop    The show on desktop value.
+	 *
+	 * @return    string    The validated value of show on desktop.
+	 */
+	public function sanitize_show_on_desktop( $show_on_desktop ) {
+
+		// Sanitize the checkbox.
+		if ( ! empty( $show_on_desktop ) ) {
+			if ( 'on' === $show_on_desktop || 'off' === $show_on_desktop ) {
+				$show_on_desktop = $show_on_desktop;
+
+			} else {
+
+				$show_on_desktop = 'off';
+
+				// Notify the user on invalid input.
+				add_settings_error( 'talkino_show_on_desktop', 'invalid_show_on_desktop_value', esc_html__( 'Oops, you have inserted invalid input of show on desktop field!', 'talkino' ), 'error' );
+
+			}
+		}
+
+		return $show_on_desktop;
+
+	}
+
+	/**
+	 * Callback function to render show on mobile field.
+	 *
+	 * @since    1.0.0
+	 */
+	public function show_on_mobile_field_callback() {
+
+		$show_on_mobile_field      = get_option( 'talkino_show_on_mobile' );
+		$is_show_on_mobile_checked = ( ! empty( $show_on_mobile_field ) && 'on' === $show_on_mobile_field ) ? 'checked' : '';
+
+		?>
+		<input name="talkino_show_on_mobile" type="hidden" value='off'/>
+		<input name="talkino_show_on_mobile" type="checkbox" <?php echo esc_attr( $is_show_on_mobile_checked ); ?> value='on' /> <?php esc_html_e( 'Enable Talkino chatbox to show on mobile.', 'talkino' ); ?>
+		<?php
+
+	}
+
+	/**
+	 * Sanitize function to validate the show on mobile field.
+	 *
+	 * @since     1.0.0
+	 * @param     string $show_on_mobile    The show on mobile value.
+	 *
+	 * @return    string    The validated value of show on mobile.
+	 */
+	public function sanitize_show_on_mobile( $show_on_mobile ) {
+
+		// Sanitize the checkbox.
+		if ( ! empty( $show_on_mobile ) ) {
+			if ( 'on' === $show_on_mobile || 'off' === $show_on_mobile ) {
+				$show_on_mobile = $show_on_mobile;
+
+			} else {
+
+				$show_on_mobile = 'off';
+
+				// Notify the user on invalid input.
+				add_settings_error( 'talkino_show_on_mobile', 'invalid_show_on_mobile_value', esc_html__( 'Oops, you have inserted invalid input of show on mobile field!', 'talkino' ), 'error' );
+
+			}
+		}
+
+		return $show_on_mobile;
+
+	}
+
+	/**
+	 * Callback function to render user visibility field.
+	 *
+	 * @since    2.0.0
+	 */
+	public function user_visibility_field_callback() {
+
+		$user_visibility_field = get_option( 'talkino_user_visibility' );
+
+		?>
+		<select name="talkino_user_visibility" class="regular-text">
+			<option value="all" <?php selected( 'all', $user_visibility_field ); ?>><?php esc_html_e( 'All users', 'talkino' ); ?></option>
+			<option value="loggedin" <?php selected( 'loggedin', $user_visibility_field ); ?>><?php esc_html_e( 'Logged in users only', 'talkino' ); ?></option>
+		</select>
+		<?php
+
+	}
+
+	/**
+	 * Sanitize function to validate the user visibility field.
+	 *
+	 * @since     2.0.0
+	 * @param     string $user_visibility_field    The user visibility_field.
+	 *
+	 * @return    string    The validated value of user visibility_field.
+	 */
+	public function sanitize_user_visibility( $user_visibility_field ) {
+
+		if ( 'all' !== $user_visibility_field && 'loggedin' !== $user_visibility_field ) {
+
+			$user_visibility_field = 'all';
+
+			// Notify the user on invalid input.
+			add_settings_error( 'talkino_user_visibility', 'invalid_user_visibility_value', esc_html__( 'Oops, you have inserted invalid input of user visibility field!', 'talkino' ), 'error' );
+
+		}
+
+		return $user_visibility_field;
 
 	}
 
@@ -2812,6 +3577,53 @@ class Talkino_Settings {
 
 	}
 
+	/********************************* Credit *********************************/
+	/**
+	 * Callback function to render credit field.
+	 *
+	 * @since    2.0.0
+	 */
+	public function credit_field_callback() {
+
+		$credit_field      = get_option( 'talkino_credit' );
+		$is_credit_checked = ( ! empty( $credit_field ) && 'on' === $credit_field ) ? 'checked' : '';
+
+		?>
+		<input name="talkino_credit" type="hidden" value='off'/>
+		<input name="talkino_credit" type="checkbox" <?php echo esc_attr( $is_credit_checked ); ?> value='on' /> <?php esc_html_e( 'Enable Talkino plugin to display credit on the chatbox.', 'talkino' ); ?>
+		<?php
+
+	}
+
+	/**
+	 * Sanitize function to validate the credit field.
+	 *
+	 * @since     2.0.0
+	 * @param     string $credit_field    The credit.
+	 *
+	 * @return    string    The validated value of credit.
+	 */
+	public function sanitize_credit( $credit_field ) {
+
+		// Sanitize the checkbox.
+		if ( ! empty( $credit_field ) ) {
+			if ( 'on' === $credit_field || 'off' === $credit_field ) {
+				$credit_field = $credit_field;
+
+			} else {
+
+				$credit_field = 'on';
+
+				// Notify the user on invalid input.
+				add_settings_error( 'talkino_credit', 'invalid_credit_value', esc_html__( 'Oops, you have inserted invalid input of credit field!', 'talkino' ), 'error' );
+
+			}
+		}
+
+		return $credit_field;
+
+	}
+
 	/********************************* Advanced *********************************/
 	/**
 	 * Callback function to render reset settings status field.
@@ -2915,8 +3727,11 @@ class Talkino_Settings {
 		if ( get_option( 'talkino_reset_settings_status' ) === 'on' ) {
 
 			/************* Settings */
+			// Reset chatbox activation.
+			update_option( 'talkino_chatbox_activation', 'active' );
+
 			// Reset global online status.
-			update_option( 'talkino_global_online_status', 'Online' );
+			update_option( 'talkino_global_online_status', 'online' );
 
 			// Reset global schedule data.
 			$global_schedule_online_status_data = array(
@@ -2952,13 +3767,10 @@ class Talkino_Settings {
 			update_option( 'talkino_chatbox_away_subtitle', 'We are currently away!' );
 
 			// Reset chatbox offline subtitle.
-			update_option( 'talkino_chatbox_offline_subtitle', 'Kindly please drop us a message and we will get back to you soon!' );
-
-			// Reset agent not available message.
-			update_option( 'talkino_agent_not_available_message', 'All agents are not available.' );
+			update_option( 'talkino_chatbox_offline_subtitle', 'Thank you for getting in touch. We are currently out of the office.' );
 
 			// Reset offline message.
-			update_option( 'talkino_offline_message', 'Sorry, we are currently offline.' );
+			update_option( 'talkino_offline_message', 'Sorry, there is no agent available.' );
 
 			// Reset chatbox button text.
 			update_option( 'talkino_chatbox_button_text', 'Chat Now' );
@@ -2974,37 +3786,64 @@ class Talkino_Settings {
 			update_option( 'talkino_chatbox_position', 'right' );
 
 			// Reset chatbox icon data.
-			update_option( 'talkino_chatbox_icon', 'fa fa-comment' );
+			update_option( 'talkino_chatbox_icon', 'dashicons-format-chat' );
 
-			// Reset load font awesome deferred data.
-			update_option( 'talkino_load_font_awesome_deferred', 'on' );
-
-			// Reset show on desktop data.
-			update_option( 'talkino_show_on_desktop', 'on' );
-
-			// Reset show on mobile data.
-			update_option( 'talkino_show_on_mobile', 'on' );
+			// Reset chatbox animation data.
+			update_option( 'talkino_chatbox_animation', 'fadein' );
 
 			// Reset start chat method.
 			update_option( 'talkino_start_chat_method', '_blank' );
 
+			// Reset chatbox z-index method.
+			update_option( 'talkino_chatbox_z_index', '9999999' );
+
 			// Reset chatbox theme color for online status.
 			update_option( 'talkino_chatbox_online_theme_color', '#1e73be' );
 
+			// Reset chatbox icon color for online status.
+			update_option( 'talkino_chatbox_online_icon_color', '#fff' );
+
 			// Reset chatbox theme color for away status.
-			update_option( 'talkino_chatbox_away_theme_color', '#ffa500' );
+			update_option( 'talkino_chatbox_away_theme_color', '#ff6000' );
+
+			// Reset chatbox icon color for away status.
+			update_option( 'talkino_chatbox_away_icon_color', '#fff' );
 
 			// Reset chatbox theme color for offline status.
-			update_option( 'talkino_chatbox_offline_theme_color', '#aec6cf' );
+			update_option( 'talkino_chatbox_offline_theme_color', '#727779' );
+
+			// Reset chatbox icon color for offline status.
+			update_option( 'talkino_chatbox_offline_icon_color', '#fff' );
 
 			// Reset chatbox background color.
-			update_option( 'talkino_chatbox_background_color', '#fff' );
+			update_option( 'talkino_chatbox_background_color', '#f0f0f1' );
 
 			// Reset chatbox title color.
 			update_option( 'talkino_chatbox_title_color', '#fff' );
 
 			// Reset chatbox subtitle color.
 			update_option( 'talkino_chatbox_subtitle_color', '#000' );
+
+			// Reset chatbox button color.
+			update_option( 'talkino_chatbox_button_color', '#727779' );
+
+			// Reset chatbox button text color.
+			update_option( 'talkino_chatbox_button_text_color', '#fff' );
+
+			// Reset agent field background color.
+			update_option( 'talkino_agent_field_background_color', '#fff' );
+
+			// Reset agent field hover background color.
+			update_option( 'talkino_agent_field_hover_background_color', '#dfdfdf' );
+
+			// Reset agent name text color.
+			update_option( 'talkino_agent_name_text_color', '#222' );
+
+			// Reset agent job title text color.
+			update_option( 'talkino_agent_job_title_text_color', '#888' );
+
+			// Reset agent channel text color.
+			update_option( 'talkino_agent_channel_text_color', '#888' );
 
 			/** Ordering */
 			// Reset agent ordering.
@@ -3017,8 +3856,20 @@ class Talkino_Settings {
 			// Reset show on search data.
 			update_option( 'talkino_show_on_search', 'on' );
 
+			// Reset show on 404 data.
+			update_option( 'talkino_show_on_404', 'on' );
+
 			// Reset show on woocommerce shop, product, product category and tag pages data.
 			update_option( 'talkino_show_on_woocommerce_pages', 'on' );
+
+			// Reset show on desktop data.
+			update_option( 'talkino_show_on_desktop', 'on' );
+
+			// Reset show on mobile data.
+			update_option( 'talkino_show_on_mobile', 'on' );
+
+			// Reset user visibility data.
+			update_option( 'talkino_user_visibility', 'all' );
 
 			/** Contact Form */
 			// Reset contact form status.
@@ -3053,6 +3904,10 @@ class Talkino_Settings {
 
 			// Reset recaptcha secret key.
 			update_option( 'talkino_recaptcha_secret_key', '' );
+
+			/** Advanced */
+			// Reset credit.
+			update_option( 'talkino_credit', 'on' );
 
 			/** Advanced */
 			// Reset data uninstall status.

--- a/includes/admin/class-talkino-tools.php
+++ b/includes/admin/class-talkino-tools.php
@@ -104,12 +104,14 @@ class Talkino_Tools {
 	 */
 	public function dismiss_plugin_review_notice() {
 
-		if ( isset( $_GET['dismiss-plugin-review-notice'] ) && ! empty( $_GET['dismiss-plugin-review-notice'] ) ) { // phpcs:ignore
-			$dismiss = (int) $_GET['dismiss-plugin-review-notice']; // phpcs:ignore
+		if ( isset( $_GET['dismiss-plugin-review-notice'] ) && ! empty( $_GET['dismiss-plugin-review-notice'] ) ) {
+			
+			$dismiss = (int) $_GET['dismiss-plugin-review-notice'];
 
 			if ( 1 === $dismiss ) {
 				add_option( 'talkino_dismiss_plugin_review_notice', true );
 			}
+			
 		}
 
 	}

--- a/includes/admin/class-talkino-upgrader.php
+++ b/includes/admin/class-talkino-upgrader.php
@@ -29,13 +29,112 @@ class Talkino_Upgrader {
 	 */
 	public function upgrade_plugin_data() {
 
-		// Remove deprecated data of chatbox height.
-		if ( get_option( 'talkino_chatbox_height' ) === true ) {
-			delete_option( 'talkino_chatbox_height' );
+		/********** Add new data **********/
+		// Add chatbox activation if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_chatbox_activation' ) === false ) {
+			add_option( 'talkino_chatbox_activation', 'active' );
 		}
 
+		// Add chatbox button text if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_chatbox_button_text' ) === false ) {
+			add_option( 'talkino_chatbox_button_text', 'Chat Now' );
+		}
+
+		// Add chatbox animation if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_chatbox_animation' ) === false ) {
+			add_option( 'talkino_chatbox_animation', 'fadein' );
+		}
+
+		// Add chatbox z-index if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_chatbox_z_index' ) === false ) {
+			add_option( 'talkino_chatbox_z_index', '9999999' );
+		}
+
+		// Add chatbox icon color for online status if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_chatbox_online_icon_color' ) === false ) {
+			add_option( 'talkino_chatbox_online_icon_color', '#fff' );
+		}
+
+		// Add chatbox icon color for away status if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_chatbox_away_icon_color' ) === false ) {
+			add_option( 'talkino_chatbox_away_icon_color', '#fff' );
+		}
+
+		// Add chatbox icon color for offline status if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_chatbox_offline_icon_color' ) === false ) {
+			add_option( 'talkino_chatbox_offline_icon_color', '#fff' );
+		}
+
+		// Add chatbox button color if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_chatbox_button_color' ) === false ) {
+			add_option( 'talkino_chatbox_button_color', '#727779' );
+		}
+
+		// Add chatbox button text color if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_chatbox_button_text_color' ) === false ) {
+			add_option( 'talkino_chatbox_button_text_color', '#fff' );
+		}
+
+		// Add agent field background color if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_agent_field_background_color' ) === false ) {
+			add_option( 'talkino_agent_field_background_color', '#f0f0f1' );
+		}
+
+		// Add agent field hover background color if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_agent_field_hover_background_color' ) === false ) {
+			add_option( 'talkino_agent_field_hover_background_color', '#dfdfdf' );
+		}
+
+		// Add agent name text color if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_agent_name_text_color' ) === false ) {
+			add_option( 'talkino_agent_name_text_color', '#222' );
+		}
+
+		// Add agent job title text color if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_agent_job_title_text_color' ) === false ) {
+			add_option( 'talkino_agent_job_title_text_color', '#888' );
+		}
+
+		// Add agent channel text color if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_agent_channel_text_color' ) === false ) {
+			add_option( 'talkino_agent_channel_text_color', '#888' );
+		}
+
+		// Add show on 404 data if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_show_on_404' ) === false ) {
+			add_option( 'talkino_show_on_404', 'on' );
+		}
+
+		// Add user visibility data if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_user_visibility' ) === false ) {
+			add_option( 'talkino_user_visibility', 'all' );
+		}
+
+		// Add credit data if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_credit' ) === false ) {
+			add_option( 'talkino_credit', 'on' );
+		}
+
+		/********** Update data based on plugin version **********/
+		// Add talkino version data if it does not exist when upgrade from old version.
+		if ( get_option( 'talkino_version' ) === false ) {
+
+			add_option( 'talkino_version', '1.2' );
+			update_option( 'talkino_chatbox_icon', 'dashicons-format-chat' );
+			update_option( 'talkino_global_online_status', strtolower( get_option( 'talkino_global_online_status' ) ) );
+
+
+		} elseif ( get_option( 'talkino_version' ) === '1.1' ) {
+
+			update_option( 'talkino_version', '1.2' );
+			update_option( 'talkino_chatbox_icon', 'dashicons-format-chat' );
+			update_option( 'talkino_global_online_status', strtolower( get_option( 'talkino_global_online_status' ) ) );
+
+		}
+
+		/********** Remove deprecated data and add new replacement data **********/ 
 		// Remove deprecated data of contact ordering.
-		if ( get_option( 'talkino_contact_ordering' ) === true ) {
+		if ( get_option( 'talkino_contact_ordering' ) !== false ) {
 			delete_option( 'talkino_contact_ordering' );
 
 			// Add a new option of channel ordering.
@@ -44,24 +143,15 @@ class Talkino_Upgrader {
 			}
 		}
 
-		// Add talkino version data if it does not exist when upgrade from old version.
-		if ( get_option( 'talkino_version' ) === false ) {
-			add_option( 'talkino_version', '1.1' );
+		/********** Remove deprecated data **********/
+		// Remove deprecated data of chatbox height.
+		if ( get_option( 'talkino_chatbox_height' ) !== false ) {
+			delete_option( 'talkino_chatbox_height' );
 		}
 
-		// Add chatbox icon data if it does not exist when upgrade from old version.
-		if ( get_option( 'talkino_chatbox_icon' ) === false ) {
-			add_option( 'talkino_chatbox_icon', 'fa fa-comment' );
-		}
-
-		// Add chatbox button text if it does not exist when upgrade from old version.
-		if ( get_option( 'talkino_chatbox_button_text' ) === false ) {
-			add_option( 'talkino_chatbox_button_text', 'Chat Now' );
-		}
-
-		// Add load font awesome deferred data if it does not exist when upgrade from old version.
-		if ( get_option( 'talkino_load_font_awesome_deferred' ) === false ) {
-			add_option( 'talkino_load_font_awesome_deferred', 'on' );
+		// Remove deprecated data of load font awesome deferred.
+		if ( get_option( 'talkino_load_font_awesome_deferred' ) !== false ) {
+			delete_option( 'talkino_load_font_awesome_deferred' );
 		}
 
 	}

--- a/includes/admin/extensions/views/html-extensions.php
+++ b/includes/admin/extensions/views/html-extensions.php
@@ -10,10 +10,9 @@
 
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {
-	die;
+    die;
 }
 
-// phpcs:disable
 ?>
 <link href="/wp-content/plugins/talkino/assets/bootstrap-5.2.1-dist/css/bootstrap.min.css" rel="stylesheet">
 
@@ -114,5 +113,4 @@ if ( ! defined( 'WPINC' ) ) {
   </main>
 </div>
 <?php
-// phpcs:enable
 ?>

--- a/includes/admin/meta-boxes/class-talkino-meta-boxes.php
+++ b/includes/admin/meta-boxes/class-talkino-meta-boxes.php
@@ -67,25 +67,27 @@ class Talkino_Meta_Boxes {
 		$post_id = $post->ID;
 
 		// Get the meta value to display on existing meta box.
-		$job_title                   = ( ! empty( get_post_meta( $post_id, 'talkino_job_title', true ) ) ) ? get_post_meta( $post_id, 'talkino_job_title', true ) : '';
-		$whatsapp_id                 = ( ! empty( get_post_meta( $post_id, 'talkino_whatsapp_id', true ) ) ) ? get_post_meta( $post_id, 'talkino_whatsapp_id', true ) : '';
-		$whatsapp_pre_filled_message = ( ! empty( get_post_meta( $post_id, 'talkino_whatsapp_pre_filled_message', true ) ) ) ? get_post_meta( $post_id, 'talkino_whatsapp_pre_filled_message', true ) : '';
-		$facebook_id                 = ( ! empty( get_post_meta( $post_id, 'talkino_facebook_id', true ) ) ) ? get_post_meta( $post_id, 'talkino_facebook_id', true ) : '';
-		$telegram_id                 = ( ! empty( get_post_meta( $post_id, 'talkino_telegram_id', true ) ) ) ? get_post_meta( $post_id, 'talkino_telegram_id', true ) : '';
-		$phone_number                = ( ! empty( get_post_meta( $post_id, 'talkino_phone_number', true ) ) ) ? get_post_meta( $post_id, 'talkino_phone_number', true ) : '';
-		$email                       = ( ! empty( get_post_meta( $post_id, 'talkino_email', true ) ) ) ? get_post_meta( $post_id, 'talkino_email', true ) : '';
+		$job_title                   	  = ( ! empty( get_post_meta( $post_id, 'talkino_job_title', true ) ) ) ? get_post_meta( $post_id, 'talkino_job_title', true ) : '';
+		$whatsapp_id                      = ( ! empty( get_post_meta( $post_id, 'talkino_whatsapp_id', true ) ) ) ? get_post_meta( $post_id, 'talkino_whatsapp_id', true ) : '';
+		$whatsapp_pre_filled_message      = ( ! empty( get_post_meta( $post_id, 'talkino_whatsapp_pre_filled_message', true ) ) ) ? get_post_meta( $post_id, 'talkino_whatsapp_pre_filled_message', true ) : '';
+		$facebook_id                      = ( ! empty( get_post_meta( $post_id, 'talkino_facebook_id', true ) ) ) ? get_post_meta( $post_id, 'talkino_facebook_id', true ) : '';
+		$telegram_id                      = ( ! empty( get_post_meta( $post_id, 'talkino_telegram_id', true ) ) ) ? get_post_meta( $post_id, 'talkino_telegram_id', true ) : '';
+		$phone_number                     = ( ! empty( get_post_meta( $post_id, 'talkino_phone_number', true ) ) ) ? get_post_meta( $post_id, 'talkino_phone_number', true ) : '';
+		$phone_show_only_on_mobile_status = ( ! empty( get_post_meta( $post_id, 'talkino_phone_show_only_on_mobile_status', true ) ) ) ? get_post_meta( $post_id, 'talkino_phone_show_only_on_mobile_status', true ) : 'off';
+		$email                            = ( ! empty( get_post_meta( $post_id, 'talkino_email', true ) ) ) ? get_post_meta( $post_id, 'talkino_email', true ) : '';
 
 		// Make sure the contents of the form came from the location on the current site and not somewhere else.
 		wp_nonce_field( basename( __FILE__ ), 'talkino_chatbox_nonce' );
 
 		$contact_data = array(
-			'job_title'                   => $job_title,
-			'whatsapp_id'                 => $whatsapp_id,
-			'whatsapp_pre_filled_message' => $whatsapp_pre_filled_message,
-			'facebook_id'                 => $facebook_id,
-			'telegram_id'                 => $telegram_id,
-			'phone_number'                => $phone_number,
-			'email'                       => $email,
+			'job_title'                        => $job_title,
+			'whatsapp_id'                      => $whatsapp_id,
+			'whatsapp_pre_filled_message'      => $whatsapp_pre_filled_message,
+			'facebook_id'                      => $facebook_id,
+			'telegram_id'                      => $telegram_id,
+			'phone_number'                     => $phone_number,
+			'phone_show_only_on_mobile_status' => $phone_show_only_on_mobile_status,
+			'email'                            => $email,
 		);
 
 		// Load html to render contact meta box.
@@ -184,7 +186,6 @@ class Talkino_Meta_Boxes {
 	 * @param    string  $post_id    Id of the post.
 	 * @param    WP_Post $post      Post object.
 	 */
-	// phpcs:disable
 	public function save_meta_box( $post_id, $post ) {
 
 		// Call the class to sanitize post meta.
@@ -204,13 +205,14 @@ class Talkino_Meta_Boxes {
 		}
 
 		// Sanitize the contact data.
-		$job_title                   = ( isset( $_POST['talkino_job_title'] ) ) ? sanitize_text_field( wp_unslash( $_POST['talkino_job_title'] ) ) : '';
-		$whatsapp_id                 = ( isset( $_POST['talkino_whatsapp_id'] ) ) ? $talkino_sanitizer->sanitize_whatsapp_phone_number( wp_unslash( $_POST['talkino_whatsapp_id'] ) ) : '';
-		$whatsapp_pre_filled_message = ( isset( $_POST['talkino_whatsapp_pre_filled_message'] ) ) ? sanitize_text_field( wp_unslash( $_POST['talkino_whatsapp_pre_filled_message'] ) ) : '';
-		$facebook_id                 = ( isset( $_POST['talkino_facebook_id'] ) ) ? sanitize_text_field( wp_unslash( $_POST['talkino_facebook_id'] ) ) : '';
-		$telegram_id                 = ( isset( $_POST['talkino_telegram_id'] ) ) ? sanitize_text_field( wp_unslash( $_POST['talkino_telegram_id'] ) ) : '';
-		$phone_number                = ( isset( $_POST['talkino_phone_number'] ) ) ? $talkino_sanitizer->sanitize_phone_number( wp_unslash( $_POST['talkino_phone_number'] ) ) : '';
-		$email                       = ( isset( $_POST['talkino_email'] ) ) ? sanitize_email( wp_unslash( $_POST['talkino_email'] ) ) : '';
+		$job_title                        = ( isset( $_POST['talkino_job_title'] ) ) ? sanitize_text_field( wp_unslash( $_POST['talkino_job_title'] ) ) : '';
+		$whatsapp_id                      = ( isset( $_POST['talkino_whatsapp_id'] ) ) ? $talkino_sanitizer->sanitize_whatsapp_phone_number( wp_unslash( $_POST['talkino_whatsapp_id'] ) ) : '';
+		$whatsapp_pre_filled_message      = ( isset( $_POST['talkino_whatsapp_pre_filled_message'] ) ) ? sanitize_text_field( wp_unslash( $_POST['talkino_whatsapp_pre_filled_message'] ) ) : '';
+		$facebook_id                      = ( isset( $_POST['talkino_facebook_id'] ) ) ? sanitize_text_field( wp_unslash( $_POST['talkino_facebook_id'] ) ) : '';
+		$telegram_id                      = ( isset( $_POST['talkino_telegram_id'] ) ) ? sanitize_text_field( wp_unslash( $_POST['talkino_telegram_id'] ) ) : '';
+		$phone_number                     = ( isset( $_POST['talkino_phone_number'] ) ) ? $talkino_sanitizer->sanitize_phone_number( wp_unslash( $_POST['talkino_phone_number'] ) ) : '';
+		$phone_show_only_on_mobile_status = ( isset( $_POST['talkino_phone_show_only_on_mobile_status'] ) ) ? $talkino_sanitizer->sanitize_phone_show_only_on_mobile_status( wp_unslash( $_POST['talkino_phone_show_only_on_mobile_status'] ) ) : 'off';
+		$email                            = ( isset( $_POST['talkino_email'] ) ) ? sanitize_email( wp_unslash( $_POST['talkino_email'] ) ) : '';
 
 		// Sanitize the options data.
 		$agent_schedule_activate_status = ( isset( $_POST['talkino_agent_schedule_activate_status'] ) ) ? $talkino_sanitizer->sanitize_agent_schedule_online_status( wp_unslash( $_POST['talkino_agent_schedule_activate_status'] ) ) : 'off';
@@ -250,6 +252,7 @@ class Talkino_Meta_Boxes {
 		update_post_meta( $post_id, 'talkino_facebook_id', $facebook_id );
 		update_post_meta( $post_id, 'talkino_telegram_id', $telegram_id );
 		update_post_meta( $post_id, 'talkino_phone_number', $phone_number );
+		update_post_meta( $post_id, 'talkino_phone_show_only_on_mobile_status', $phone_show_only_on_mobile_status );
 		update_post_meta( $post_id, 'talkino_email', $email );
 
 		// Update options post meta.
@@ -289,5 +292,5 @@ class Talkino_Meta_Boxes {
 		}
 
 	}
-	// phpcs:enable
+	
 }

--- a/includes/admin/meta-boxes/views/html-meta-box-contact.php
+++ b/includes/admin/meta-boxes/views/html-meta-box-contact.php
@@ -12,6 +12,10 @@
 if ( ! defined( 'WPINC' ) ) {
 	die;
 }
+
+// Declare the values of show on mobile status.
+$is_phone_show_only_on_mobile_status_checked = ( ! empty( $data['phone_show_only_on_mobile_status'] ) && 'on' === $data['phone_show_only_on_mobile_status'] ) ? 'checked' : '';
+
 ?>
 
 <div>
@@ -27,7 +31,7 @@ if ( ! defined( 'WPINC' ) ) {
 		<p class="talkino-whatsapp-title">
 			<label><b><?php esc_html_e( 'WhatsApp/ WhatsApp Business ID:', 'talkino' ); ?></b></label><br>
 			<input type="tel" name="talkino_whatsapp_id" class="talkino-whatsapp-input" value="<?php echo esc_attr( $data['whatsapp_id'] ); ?>" /><br>
-			<label><i><?php esc_html_e( 'Use full phone number in international format or leave it empty to deactivate WhatsApp.', 'talkino' ); ?></i></label>
+			<label><i><?php esc_html_e( 'Use full phone number in international format ( i.e. 12345678901 ) or leave it empty to deactivate WhatsApp.', 'talkino' ); ?></i></label>
 		</p>
 		<p class="talkino-whatsapp-prefilled-message-title">
 			<label><b><?php esc_html_e( 'WhatsApp Pre-filled Message:', 'talkino' ); ?></b></label><br>
@@ -56,6 +60,9 @@ if ( ! defined( 'WPINC' ) ) {
 		<p class="talkino-phone-title">
 			<label><b><?php esc_html_e( 'Phone Number:', 'talkino' ); ?></b></label><br>
 			<input type="tel" name="talkino_phone_number" class="talkino-phone-input" value="<?php echo esc_attr( $data['phone_number'] ); ?>" /><br>
+			<input name="talkino_phone_show_only_on_mobile_status" type="hidden" value='off' />
+			<input id="talkino_phone_show_only_on_mobile_status" name="talkino_phone_show_only_on_mobile_status" type="checkbox" <?php echo esc_attr( $is_phone_show_only_on_mobile_status_checked ); ?> value='on' />
+			<label class="show_only_on_mobile_view"><?php esc_html_e( 'Show only on mobile view?', 'talkino' ); ?></label><br>
 			<label><i><?php esc_html_e( 'Key in phone number or leave it empty if you want to deactivate it. Note: Only shown on mobile or tablet devices.', 'talkino' ); ?></i></label>
 		</p>
 	</div>	

--- a/includes/class-talkino-activator.php
+++ b/includes/class-talkino-activator.php
@@ -59,6 +59,7 @@ class Talkino_Activator {
 				if ( ! check_admin_referer( 'activate-plugin_' . self::$request['plugin'] ) ) {
 					exit;
 				}
+
 			} elseif ( isset( $_REQUEST['checked'] ) ) {
 				if ( ! check_admin_referer( 'bulk-plugins' ) ) {
 					exit;
@@ -101,6 +102,7 @@ class Talkino_Activator {
 					return self::$request;
 
 				}
+
 			} elseif ( isset( $_REQUEST['checked'] ) ) {
 				if ( false !== wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'bulk-plugins' ) ) {
 
@@ -108,8 +110,10 @@ class Talkino_Activator {
 					self::$request['plugins'] = array_map( 'sanitize_text_field', wp_unslash( $_REQUEST['checked'] ) );
 
 					return self::$request;
+					
 				}
 			}
+
 		} else {
 			return false;
 		}
@@ -168,13 +172,18 @@ class Talkino_Activator {
 		// Global options.
 		// Add talkino version if it does not exist.
 		if ( get_option( 'talkino_version' ) === false ) {
-			add_option( 'talkino_version', '1.1' );
+			add_option( 'talkino_version', '1.2' );
 		}
 
 		// Settings options.
+		// Add chatbox activation if it does not exist.
+		if ( get_option( 'talkino_chatbox_activation' ) === false ) {
+			add_option( 'talkino_chatbox_activation', 'active' );
+		}
+
 		// Add global online status if it does not exist.
 		if ( get_option( 'talkino_global_online_status' ) === false ) {
-			add_option( 'talkino_global_online_status', 'Online' );
+			add_option( 'talkino_global_online_status', 'online' );
 		}
 
 		// Add global schedule data if they do not exist.
@@ -220,17 +229,12 @@ class Talkino_Activator {
 
 		// Add chatbox offline subtitle if it does not exist.
 		if ( get_option( 'talkino_chatbox_offline_subtitle' ) === false ) {
-			add_option( 'talkino_chatbox_offline_subtitle', 'Kindly please drop us a message and we will get back to you soon!' );
-		}
-
-		// Add agent not available message if it does not exist.
-		if ( get_option( 'talkino_agent_not_available_message' ) === false ) {
-			add_option( 'talkino_agent_not_available_message', 'All agents are not available.' );
+			add_option( 'talkino_chatbox_offline_subtitle', 'Thank you for getting in touch. We are currently out of the office.' );
 		}
 
 		// Add offline message if it does not exist.
 		if ( get_option( 'talkino_offline_message' ) === false ) {
-			add_option( 'talkino_offline_message', 'Sorry, we are currently offline.' );
+			add_option( 'talkino_offline_message', 'Sorry, there is no agent available.' );
 		}
 
 		// Add chatbox button text if it does not exist.
@@ -251,22 +255,12 @@ class Talkino_Activator {
 
 		// Add chatbox icon data if it does not exist.
 		if ( get_option( 'talkino_chatbox_icon' ) === false ) {
-			add_option( 'talkino_chatbox_icon', 'fa fa-comment' );
+			add_option( 'talkino_chatbox_icon', 'dashicons-format-chat' );
 		}
 
-		// Add load font awesome deferred data if it does not exist.
-		if ( get_option( 'talkino_load_font_awesome_deferred' ) === false ) {
-			add_option( 'talkino_load_font_awesome_deferred', 'on' );
-		}
-
-		// Add show on desktop data if it does not exist.
-		if ( get_option( 'talkino_show_on_desktop' ) === false ) {
-			add_option( 'talkino_show_on_desktop', 'on' );
-		}
-
-		// Add show on mobile data if it does not exist.
-		if ( get_option( 'talkino_show_on_mobile' ) === false ) {
-			add_option( 'talkino_show_on_mobile', 'on' );
+		// Add chatbox animation data if it does not exist.
+		if ( get_option( 'talkino_chatbox_animation' ) === false ) {
+			add_option( 'talkino_chatbox_animation', 'fadein' );
 		}
 
 		// Add start chat method if it does not exist.
@@ -274,24 +268,44 @@ class Talkino_Activator {
 			add_option( 'talkino_start_chat_method', '_blank' );
 		}
 
+		// Add chatbox z-index if it does not exist.
+		if ( get_option( 'talkino_chatbox_z_index' ) === false ) {
+			add_option( 'talkino_chatbox_z_index', '9999999' );
+		}
+
 		// Add chatbox theme color for online status if it does not exist.
 		if ( get_option( 'talkino_chatbox_online_theme_color' ) === false ) {
 			add_option( 'talkino_chatbox_online_theme_color', '#1e73be' );
 		}
 
+		// Add chatbox icon color for online status if it does not exist.
+		if ( get_option( 'talkino_chatbox_online_icon_color' ) === false ) {
+			add_option( 'talkino_chatbox_online_icon_color', '#fff' );
+		}
+
 		// Add chatbox theme color for away status if it does not exist.
 		if ( get_option( 'talkino_chatbox_away_theme_color' ) === false ) {
-			add_option( 'talkino_chatbox_away_theme_color', '#ffa500' );
+			add_option( 'talkino_chatbox_away_theme_color', '#ff6000' );
+		}
+
+		// Add chatbox icon color for away status if it does not exist.
+		if ( get_option( 'talkino_chatbox_away_icon_color' ) === false ) {
+			add_option( 'talkino_chatbox_away_icon_color', '#fff' );
 		}
 
 		// Add chatbox theme color for offline status if it does not exist.
 		if ( get_option( 'talkino_chatbox_offline_theme_color' ) === false ) {
-			add_option( 'talkino_chatbox_offline_theme_color', '#aec6cf' );
+			add_option( 'talkino_chatbox_offline_theme_color', '#727779' );
+		}
+
+		// Add chatbox icon color for offline status if it does not exist.
+		if ( get_option( 'talkino_chatbox_offline_icon_color' ) === false ) {
+			add_option( 'talkino_chatbox_offline_icon_color', '#fff' );
 		}
 
 		// Add chatbox background color if it does not exist.
 		if ( get_option( 'talkino_chatbox_background_color' ) === false ) {
-			add_option( 'talkino_chatbox_background_color', '#fff' );
+			add_option( 'talkino_chatbox_background_color', '#f0f0f1' );
 		}
 
 		// Add chatbox title color if it does not exist.
@@ -304,6 +318,41 @@ class Talkino_Activator {
 			add_option( 'talkino_chatbox_subtitle_color', '#000' );
 		}
 
+		// Add chatbox button color if it does not exist.
+		if ( get_option( 'talkino_chatbox_button_color' ) === false ) {
+			add_option( 'talkino_chatbox_button_color', '#727779' );
+		}
+
+		// Add chatbox button text color if it does not exist.
+		if ( get_option( 'talkino_chatbox_button_text_color' ) === false ) {
+			add_option( 'talkino_chatbox_button_text_color', '#fff' );
+		}
+
+		// Add agent field background color if it does not exist.
+		if ( get_option( 'talkino_agent_field_background_color' ) === false ) {
+			add_option( 'talkino_agent_field_background_color', '#fff' );
+		}
+
+		// Add agent field hover background color if it does not exist.
+		if ( get_option( 'talkino_agent_field_hover_background_color' ) === false ) {
+			add_option( 'talkino_agent_field_hover_background_color', '#dfdfdf' );
+		}
+		
+		// Add agent name text color if it does not exist.
+		if ( get_option( 'talkino_agent_name_text_color' ) === false ) {
+			add_option( 'talkino_agent_name_text_color', '#222' );
+		}
+
+		// Add agent job title text color if it does not exist.
+		if ( get_option( 'talkino_agent_job_title_text_color' ) === false ) {
+			add_option( 'talkino_agent_job_title_text_color', '#888' );
+		}
+
+		// Add agent channel text color if it does not exist.
+		if ( get_option( 'talkino_agent_channel_text_color' ) === false ) {
+			add_option( 'talkino_agent_channel_text_color', '#888' );
+		}
+				
 		// Ordering options.
 		// Add agent ordering if it does not exist.
 		if ( get_option( 'talkino_channel_ordering' ) === false ) {
@@ -321,9 +370,29 @@ class Talkino_Activator {
 			add_option( 'talkino_show_on_search', 'on' );
 		}
 
+		// Add show on 404 data if it does not exist.
+		if ( get_option( 'talkino_show_on_404' ) === false ) {
+			add_option( 'talkino_show_on_404', 'on' );
+		}
+
 		// Add show on woocommerce shop, product, product category and tag pages data if it does not exist.
 		if ( get_option( 'talkino_show_on_woocommerce_pages' ) === false ) {
 			add_option( 'talkino_show_on_woocommerce_pages', 'on' );
+		}
+
+		// Add show on desktop data if it does not exist.
+		if ( get_option( 'talkino_show_on_desktop' ) === false ) {
+			add_option( 'talkino_show_on_desktop', 'on' );
+		}
+
+		// Add show on mobile data if it does not exist.
+		if ( get_option( 'talkino_show_on_mobile' ) === false ) {
+			add_option( 'talkino_show_on_mobile', 'on' );
+		}
+
+		// Add user visibility data if it does not exist.
+		if ( get_option( 'talkino_user_visibility' ) === false ) {
+			add_option( 'talkino_user_visibility', 'all' );
 		}
 
 		// Contact Form options.
@@ -382,8 +451,14 @@ class Talkino_Activator {
 			add_option( 'talkino_recaptcha_secret_key', '' );
 		}
 
+		// Credit options.
+		// Add credit data if it does not exist.
+		if ( get_option( 'talkino_credit' ) === false ) {
+			add_option( 'talkino_credit', 'on' );
+		}
+
 		// Advanced options.
-		// Add data uninstall status if it does not exist.
+		// Add reset settings status data if it does not exist.
 		if ( get_option( 'talkino_reset_settings_status' ) === false ) {
 			add_option( 'talkino_reset_settings_status', 'off' );
 		}

--- a/includes/class-talkino-deactivator.php
+++ b/includes/class-talkino-deactivator.php
@@ -59,6 +59,7 @@ class Talkino_Deactivator {
 				if ( ! check_admin_referer( 'deactivate-plugin_' . self::$request['plugin'] ) ) {
 					exit;
 				}
+
 			} elseif ( isset( $_REQUEST['checked'] ) ) {
 				if ( ! check_admin_referer( 'bulk-plugins' ) ) {
 					exit;
@@ -98,6 +99,7 @@ class Talkino_Deactivator {
 					return self::$request;
 
 				}
+
 			} elseif ( isset( $_REQUEST['checked'] ) ) {
 				if ( false !== wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'bulk-plugins' ) ) {
 
@@ -108,6 +110,7 @@ class Talkino_Deactivator {
 
 				}
 			}
+			
 		} else {
 			return false;
 		}

--- a/includes/class-talkino-i18n.php
+++ b/includes/class-talkino-i18n.php
@@ -55,7 +55,6 @@ class Talkino_I18n {
 		do_action( 'wpml_register_single_string', 'talkino', 'Chatbox Online Subtitle', get_option( 'talkino_chatbox_online_subtitle' ) );
 		do_action( 'wpml_register_single_string', 'talkino', 'Chatbox Away Subtitle', get_option( 'talkino_chatbox_away_subtitle' ) );
 		do_action( 'wpml_register_single_string', 'talkino', 'Chatbox Offline Subtitle', get_option( 'talkino_chatbox_offline_subtitle' ) );
-		do_action( 'wpml_register_single_string', 'talkino', 'Agent Not Available Message', get_option( 'talkino_agent_not_available_message' ) );
 		do_action( 'wpml_register_single_string', 'talkino', 'Offline Message', get_option( 'talkino_offline_message' ) );
 		do_action( 'wpml_register_single_string', 'talkino', 'Chatbox Button Text', get_option( 'talkino_chatbox_button_text' ) );
 

--- a/includes/class-talkino.php
+++ b/includes/class-talkino.php
@@ -183,12 +183,7 @@ class Talkino {
 		$talkino_settings   = new Talkino_Settings();
 
 		// Enqueue all the scripts and stylesheets.
-		if ( get_option( 'talkino_load_font_awesome_deferred' ) === 'on' ) {
-			$this->loader->add_action( 'admin_enqueue_scripts', $talkino_admin, 'enqueue_styles', 999 );
-		} else {
-			$this->loader->add_action( 'admin_enqueue_scripts', $talkino_admin, 'enqueue_styles' );
-		}
-
+		$this->loader->add_action( 'admin_enqueue_scripts', $talkino_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $talkino_admin, 'enqueue_scripts' );
 
 		// Register hook to upgrade plugin data.
@@ -224,6 +219,9 @@ class Talkino {
 		// Register hook to change the notification message on bulk of custom post type.
 		$this->loader->add_filter( 'bulk_post_updated_messages', $talkino_customizer, 'edit_bulk_post_updated_messages', 10, 2 );
 
+		// Register hook to add premium plugin link.
+		$this->loader->add_filter( 'plugin_action_links_' . TALKINO_BASE_NAME, $talkino_customizer, 'add_premium_plugin_link' );
+
 		// Register hook to create settings of submenu page.
 		$this->loader->add_action( 'admin_menu', $talkino_settings, 'create_settings_submenu_page' );
 
@@ -252,16 +250,15 @@ class Talkino {
 		$talkino_frontend = new Talkino_Frontend( $this->get_plugin_name(), $this->get_plugin_prefix(), $this->get_version() );
 		$talkino_chatbox  = new Talkino_Chatbox();
 
-		if ( get_option( 'talkino_load_font_awesome_deferred' ) === 'on' ) {
-			$this->loader->add_action( 'wp_enqueue_scripts', $talkino_frontend, 'enqueue_styles', 9999 );
-		} else {
-			$this->loader->add_action( 'wp_enqueue_scripts', $talkino_frontend, 'enqueue_styles' );
-		}
-
+		// Enqueue all the scripts and stylesheets.
+		$this->loader->add_action( 'wp_enqueue_scripts', $talkino_frontend, 'enqueue_styles' );
 		$this->loader->add_action( 'wp_enqueue_scripts', $talkino_frontend, 'enqueue_scripts' );
 
-		// Register hook to initialize chatbox.
-		$this->loader->add_filter( 'wp_head', $talkino_chatbox, 'chatbox_init' );
+		// Register hook to initialize chatbox if chatbox activation is active.
+		if (get_option( 'talkino_chatbox_activation' ) === 'active' )
+		{
+			$this->loader->add_filter( 'wp_head', $talkino_chatbox, 'chatbox_init' );
+		}
 
 		// Register bundle hook to initialize contact form.
 		if ( is_plugin_active( 'talkino-bundle/talkino-bundle.php' ) ) {

--- a/includes/frontend/class-talkino-agent-manager.php
+++ b/includes/frontend/class-talkino-agent-manager.php
@@ -92,7 +92,7 @@ class Talkino_Agent_Manager {
 			'post_type'      => 'talkino_agents',
 			'post_status'    => 'publish',
 			'posts_per_page' => -1,
-			'meta_key'       => 'talkino_agent_ordering',// phpcs:ignore
+			'meta_key'       => 'talkino_agent_ordering',
 			'orderby'        => 'meta_value_num',
 			'order'          => 'ASC',
 		);
@@ -179,7 +179,7 @@ class Talkino_Agent_Manager {
 					}
 
 						$facebook_data .= "
-                        
+
                             <img class='talkino-channel-icon' src='" . plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/images/facebook-icon.png' . "' />
                         </div>
 
@@ -225,8 +225,8 @@ class Talkino_Agent_Manager {
 
 				}
 
-				// Ensure only query the data if there is phone number.
-				if ( wp_is_mobile() && ! empty( get_post_meta( $post_id, 'talkino_phone_number', true ) ) ) {
+				// Ensure only query the data if it is mobile view or it is desktop view and talkino_phone_show_only_on_mobile_status is off.
+				if ( ( wp_is_mobile() && ! empty( get_post_meta( $post_id, 'talkino_phone_number', true ) ) ) || ( ! wp_is_mobile() && ! empty( get_post_meta( $post_id, 'talkino_phone_number', true ) ) && ! empty( get_post_meta( $post_id, 'talkino_phone_show_only_on_mobile_status', true ) ) && get_post_meta( $post_id, 'talkino_phone_show_only_on_mobile_status', true ) === 'off'  ) ) {
 
 					$phone_number = get_post_meta( $post_id, 'talkino_phone_number', true );
 

--- a/includes/frontend/class-talkino-frontend.php
+++ b/includes/frontend/class-talkino-frontend.php
@@ -77,10 +77,12 @@ class Talkino_Frontend {
 
 		wp_enqueue_style( 'talkino-frontend', plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/css/talkino-frontend.css', array(), $this->version, 'all' );
 
-		// Enqueue bootstrap and font awesome css for chatbox.
-		wp_enqueue_style( 'bootstrap-min', plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/bootstrap-5.2.1-dist/css/bootstrap.min.css', array(), '5.2.1', 'all' );
-		wp_enqueue_style( 'font-awesome-min', plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/fontawesome-free-6.2.0-web/css/all.min.css', array(), '6.2.0', 'all' );
+		// Enqueue bootstrap css for chatbox.
+		//wp_enqueue_style( 'bootstrap-min', plugin_dir_url( TALKINO_BASE_NAME ) . 'assets/bootstrap-5.2.1-dist/css/bootstrap.min.css', array(), '5.2.1', 'all' );
 
+		// Enqueue dashicons for chatbox.
+		wp_enqueue_style( 'dashicons' );
+	
 	}
 
 	/**
@@ -94,7 +96,7 @@ class Talkino_Frontend {
 
 		// Enqueue the google recaptcha script if google recaptcha settings are activated.
 		if ( get_option( 'talkino_recaptcha_status' ) === 'on' && get_option( 'talkino_recaptcha_site_key' ) !== '' && get_option( 'talkino_recaptcha_secret_key' ) !== '' ) {
-			wp_enqueue_script( 'google-recaptcha', '//www.google.com/recaptcha/api.js?render=' . get_option( 'talkino_recaptcha_site_key' ), array( 'jquery' ), $this->version, true );
+			wp_enqueue_script( 'google-recaptcha-js', '//www.google.com/recaptcha/api.js?render=' . get_option( 'talkino_recaptcha_site_key' ), array( 'jquery' ), $this->version, true );
 		}
 
 		// Pass $php_vars array to javascript as php object for contact form.

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Contributors: traxconn, yipchunmun, leesuijen
 Donate link: https://traxconn.com/
 Tags: click to chat, whatsapp, whatsapp business, facebook messenger, telegram
 Requires at least: 4.9
-Tested up to: 6.0.2
-Stable tag: 1.1.8
+Tested up to: 6.1
+Stable tag: 2.0.0
 Requires PHP: 7.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,8 +39,14 @@ Changing your online status is all about setting the right expectation for your 
 - **Editable text**
 Enable you to edit the text of Talkino's chatbox in different modes. These include online, away and offline modes.
 
+- **Chatbox animation**
+Change the animation of the chatbox whether fade in or slide up animation.
+
+- **Color templates**
+Color templates for the chatbox are ready for you to choose.
+
 - **Fully customizable style**
-Customize the theme color, icon, styles, text color, background and position of chatbox to meet your favorite style or theme design.
+Customize the theme color, chatbox icon, button icon, styles, text color, background and position of chatbox to meet your favorite style or theme design.
 
 - **WooCommerce compatible**
 Talkino is fully compatible with WooCommerce store.
@@ -164,11 +170,32 @@ Kindly please visit  [here](https://traxconn.com/plugins/talkino/) to explore Ta
 4. Agent's Contact Details
 5. Chatbox Online Status and Editable Text of Chatbox
 6. Customizable Styles of Chatbox
-7. Feature of Ordering for Chat Channels and Agents
-8. Feature to Display or Hide the Chatbox on Pages
-9. Advanced Setting to Control the Options of Reset Settings and Uninstallation 
+7. Customizable Styles of Chatbox
+8. Customizable Styles of Chatbox
+9. Feature of Ordering for Chat Channels and Agents
+10. Feature to Display or Hide the Chatbox on Pages
+11. Feature to Show or Hide credit of Talkino on Chatbox
+12. Advanced Setting to Control the Options of Reset Settings and Uninstallation 
 
 == Changelog ==
+
+= 2.0.0, Oct 26, 2022 =
+* Added: New WordPress official dashicons with search feature for chatbox icon.
+* Added: Option to show or hide chatbox on 404 page.
+* Added: New animation of chatbox and settings.
+* Added: Option to show chatbox only on mobile view for phone.
+* Added: New close button at the top of chatbox.
+* Added: New design of chatbox.
+* Added: New color templates for chatbox.
+* Added: New customization of color template.
+* Added: New settings of Styles.
+* Added: Premium link on plugin page.
+* Added: New settings of chatbox z-index field.
+* Added: New feature to display or hide credit of Talkino.
+* Fixed: Display chatbox under offline mode when all agents are not available or global schedule is offline.
+* Fixed: Scollbar background color on certain versions of web browsers.
+* Removed: Font Awesome icon for chatbox to prevent theme conflict in future.
+* Removed: The deprecated data of Font Awesome.
 
 = 1.1.8, Oct 10, 2022 =
 * Fixed: The bug of ordering for chat channels and agents.

--- a/talkino.php
+++ b/talkino.php
@@ -10,11 +10,11 @@
  * Plugin Name:       Talkino
  * Plugin URI:        https://traxconn.com/
  * Description:       Talkino allows you to integrate multi social messengers and contact into your website and enable your users to contact you using multi social messengers' accounts.
- * Version:           1.1.8
+ * Version:           2.0.0
  * Author:            Traxconn
  * Requires at least: 4.9
  * Requires PHP:      7.3
- * Tested up to:      6.0.2
+ * Tested up to:      6.1
  * Author URI:        https://traxconn.com/user/traxconn/
  * License:           GPL-2.0+
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.txt
@@ -30,7 +30,7 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * Current plugin version.
  */
-define( 'TALKINO_VERSION', '1.1.8' );
+define( 'TALKINO_VERSION', '2.0.0' );
 
 /**
  * Define the Plugin basename.

--- a/templates/chatbox-away.php
+++ b/templates/chatbox-away.php
@@ -16,13 +16,11 @@ if ( ! defined( 'WPINC' ) ) {
 if ( is_plugin_active( 'wpml-string-translation/plugin.php' ) ) {
 
 	$talkino_chat_subtitle               = apply_filters( 'wpml_translate_single_string', get_option( 'talkino_chatbox_away_subtitle' ), 'talkino', 'Chatbox Away Subtitle' );
-	$talkino_agent_not_available_message = apply_filters( 'wpml_translate_single_string', get_option( 'talkino_agent_not_available_message' ), 'talkino', 'Agent Not Available Message' );
 	$talkino_chatbox_button_text         = apply_filters( 'wpml_translate_single_string', get_option( 'talkino_chatbox_button_text' ), 'talkino', 'Chatbox Button Text' );
 
 } else {
 
 	$talkino_chat_subtitle               = get_option( 'talkino_chatbox_away_subtitle' );
-	$talkino_agent_not_available_message = get_option( 'talkino_agent_not_available_message' );
 	$talkino_chatbox_button_text         = get_option( 'talkino_chatbox_button_text' );
 
 }
@@ -30,36 +28,40 @@ if ( is_plugin_active( 'wpml-string-translation/plugin.php' ) ) {
 <input type="checkbox" id="check"> 
 <label class="talkino-chat-btn" for="check"> 
 	<div class="talkino-icon">
-		<i class="<?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> round talkino"></i>
+		<i class="dashicons <?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> round talkino"></i>
 	</div>
-	<div class="talkino-rectangle-label"><i class="<?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> rectangle fa-xl talkino"></i> <?php echo esc_html( $talkino_chatbox_button_text ); ?></div>
-	<i class="fa fa-close talkino-close"></i> 
+	<div class="talkino-rectangle-label">
+		<?php echo esc_html( $talkino_chatbox_button_text ); ?><i class="dashicons <?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> rectangle talkino"></i>
+	</div>
 </label>
 <div class="talkino-chat-wrapper">
 	<div class="talkino-chat-title">
-	<b><?php esc_html_e( 'Away', 'talkino' ); ?></b>
+		<b><?php esc_html_e( 'Away', 'talkino' ); ?></b>
+		<label class="talkino-chat-close" for="check">
+				<i class="dashicons dashicons-minus talkino-chat-close-btn"></i>
+		</label> 
 	</div>
 	<div class="talkino-chat-subtitle"> 
 		<span><?php echo esc_html( $talkino_chat_subtitle ); ?></span> 
 	</div>
 	<div class="talkino-information-wrapper">
 		<?php
-		// If there is no agent available.
-		if ( '' === $data['first_output'] && '' === $data['second_output'] && '' === $data['third_output'] && '' === $data['fourth_output'] && '' === $data['fifth_output'] ) {
 
-			?>
-				<div class="talkino-notice"><i> <?php echo esc_html( $talkino_agent_not_available_message ); ?> </i></div>
-			<?php
+		echo wp_kses_post( $data['first_output'] );
+		echo wp_kses_post( $data['second_output'] );
+		echo wp_kses_post( $data['third_output'] );
+		echo wp_kses_post( $data['fourth_output'] );
+		echo wp_kses_post( $data['fifth_output'] );
 
-		} else {
-
-			echo wp_kses_post( $data['first_output'] );
-			echo wp_kses_post( $data['second_output'] );
-			echo wp_kses_post( $data['third_output'] );
-			echo wp_kses_post( $data['fourth_output'] );
-			echo wp_kses_post( $data['fifth_output'] );
-
-		}
 		?>
 	</div>
+	<?php 
+	if ( get_option( 'talkino_credit' ) === 'on' ) {
+	?>
+	<div class="talkino-footer-wrapper">
+		<a class="talkino-credit-link" href="https://traxconn.com/plugins/talkino/" target=”_blank”>Powered by Talkino</a> 
+	</div>
+	<?php
+	}
+	?>
 </div>

--- a/templates/chatbox-offline.php
+++ b/templates/chatbox-offline.php
@@ -30,14 +30,18 @@ if ( is_plugin_active( 'wpml-string-translation/plugin.php' ) ) {
 <input type="checkbox" id="check"> 
 <label class="talkino-chat-btn" for="check"> 
 	<div class="talkino-icon">
-		<i class="<?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> round talkino"></i>
+		<i class="dashicons <?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> round talkino"></i>
 	</div>
-	<div class="talkino-rectangle-label"><i class="<?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> rectangle fa-xl talkino"></i> <?php echo esc_html( $talkino_chatbox_button_text ); ?></div>
-	<i class="fa fa-close talkino-close"></i> 
+	<div class="talkino-rectangle-label">
+		<?php echo esc_html( $talkino_chatbox_button_text ); ?><i class="dashicons <?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> rectangle talkino"></i>
+	</div>
 </label>
 <div class="talkino-chat-wrapper">
 	<div class="talkino-chat-title">
-	<b><?php esc_html_e( 'Offline', 'talkino' ); ?></b>
+		<b><?php esc_html_e( 'Offline', 'talkino' ); ?></b>
+		<label class="talkino-chat-close" for="check">
+				<i class="dashicons dashicons-minus talkino-chat-close-btn"></i>
+		</label> 
 	</div>
 	<div class="talkino-chat-subtitle"> 
 		<span><?php echo esc_html( $talkino_chat_subtitle ); ?></span> 
@@ -45,4 +49,13 @@ if ( is_plugin_active( 'wpml-string-translation/plugin.php' ) ) {
 	<div class="talkino-information-wrapper">
 		<div class="talkino-notice"><i><?php echo esc_html( $talkino_offline_message ); ?></i></div>
 	</div>
+	<?php 
+	if ( get_option( 'talkino_credit' ) === 'on' ) {
+	?>
+	<div class="talkino-footer-wrapper">
+		<a class="talkino-credit-link" href="https://traxconn.com/plugins/talkino/" target=”_blank”>Powered by Talkino</a> 
+	</div>
+	<?php
+	}
+	?>
 </div>

--- a/templates/chatbox-online.php
+++ b/templates/chatbox-online.php
@@ -16,13 +16,11 @@ if ( ! defined( 'WPINC' ) ) {
 if ( is_plugin_active( 'wpml-string-translation/plugin.php' ) ) {
 
 	$talkino_chat_subtitle               = apply_filters( 'wpml_translate_single_string', get_option( 'talkino_chatbox_online_subtitle' ), 'talkino', 'Chatbox Online Subtitle' );
-	$talkino_agent_not_available_message = apply_filters( 'wpml_translate_single_string', get_option( 'talkino_agent_not_available_message' ), 'talkino', 'Agent Not Available Message' );
 	$talkino_chatbox_button_text         = apply_filters( 'wpml_translate_single_string', get_option( 'talkino_chatbox_button_text' ), 'talkino', 'Chatbox Button Text' );
 
 } else {
 
 	$talkino_chat_subtitle               = get_option( 'talkino_chatbox_online_subtitle' );
-	$talkino_agent_not_available_message = get_option( 'talkino_agent_not_available_message' );
 	$talkino_chatbox_button_text         = get_option( 'talkino_chatbox_button_text' );
 
 }
@@ -31,36 +29,40 @@ if ( is_plugin_active( 'wpml-string-translation/plugin.php' ) ) {
 <input type="checkbox" id="check"> 
 <label class="talkino-chat-btn" for="check"> 
 	<div class="talkino-icon">
-		<i class="<?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> round talkino"></i>
+		<i class="dashicons <?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> round talkino"></i>
 	</div>
-	<div class="talkino-rectangle-label"><i class="<?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> rectangle fa-xl talkino"></i> <?php echo esc_html( $talkino_chatbox_button_text ); ?></div>
-	<i class="fa fa-close talkino-close"></i> 
+	<div class="talkino-rectangle-label">
+		<?php echo esc_html( $talkino_chatbox_button_text ); ?><i class="dashicons <?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> rectangle talkino"></i>
+	</div>
 </label>
 <div class="talkino-chat-wrapper">
 	<div class="talkino-chat-title">
 		<b><?php esc_html_e( 'Online', 'talkino' ); ?></b>
+		<label class="talkino-chat-close" for="check">
+			<i class="dashicons dashicons-minus talkino-chat-close-btn"></i>
+		</label> 
 	</div>	
 	<div class="talkino-chat-subtitle"> 
 		<span><?php echo esc_html( $talkino_chat_subtitle ); ?></span> 
 	</div>	
 	<div class="talkino-information-wrapper">
 		<?php
-		// If there is no agent available.
-		if ( '' === $data['first_output'] && '' === $data['second_output'] && '' === $data['third_output'] && '' === $data['fourth_output'] && '' === $data['fifth_output'] ) {
+		
+		echo wp_kses_post( $data['first_output'] );
+		echo wp_kses_post( $data['second_output'] );
+		echo wp_kses_post( $data['third_output'] );
+		echo wp_kses_post( $data['fourth_output'] );
+		echo wp_kses_post( $data['fifth_output'] );
 
-			?>
-				<div class="talkino-notice"><i> <?php echo esc_html( $talkino_agent_not_available_message ); ?> </i></div>
-			<?php
-
-		} else {
-
-			echo wp_kses_post( $data['first_output'] );
-			echo wp_kses_post( $data['second_output'] );
-			echo wp_kses_post( $data['third_output'] );
-			echo wp_kses_post( $data['fourth_output'] );
-			echo wp_kses_post( $data['fifth_output'] );
-
-		}
 		?>
 	</div>
+	<?php 
+	if ( get_option( 'talkino_credit' ) === 'on' ) {
+	?>
+	<div class="talkino-footer-wrapper">
+		<a class="talkino-credit-link" href="https://traxconn.com/plugins/talkino/" target=”_blank”>Powered by Talkino</a> 
+	</div>
+	<?php
+	}
+	?>
 </div>

--- a/templates/contact-form.php
+++ b/templates/contact-form.php
@@ -17,11 +17,13 @@ if ( is_plugin_active( 'wpml-string-translation/plugin.php' ) ) {
 
 	$talkino_chat_subtitle   = apply_filters( 'wpml_translate_single_string', get_option( 'talkino_chatbox_offline_subtitle' ), 'talkino', 'Chatbox Offline Subtitle' );
 	$talkino_offline_message = apply_filters( 'wpml_translate_single_string', get_option( 'talkino_offline_message' ), 'talkino', 'Offline Message' );
+	$talkino_chatbox_button_text         = apply_filters( 'wpml_translate_single_string', get_option( 'talkino_chatbox_button_text' ), 'talkino', 'Chatbox Button Text' );
 
 } else {
 
 	$talkino_chat_subtitle   = get_option( 'talkino_chatbox_offline_subtitle' );
 	$talkino_offline_message = get_option( 'talkino_offline_message' );
+	$talkino_chatbox_button_text = get_option( 'talkino_chatbox_button_text' );
 
 }
 
@@ -29,14 +31,18 @@ if ( is_plugin_active( 'wpml-string-translation/plugin.php' ) ) {
 <input type="checkbox" id="check"> 
 <label class="talkino-chat-btn" for="check"> 
 	<div class="talkino-icon">
-		<i class="<?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> round"></i>
+		<i class="dashicons <?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> round talkino"></i>
 	</div>
-	<div class="talkino-rectangle-label"><i class="<?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> rectangle fa-xl"></i> <?php esc_html_e( 'Chat Now', 'talkino' ); ?></div>
-	<i class="fa fa-close talkino-close"></i> 
+	<div class="talkino-rectangle-label">
+		<?php echo esc_html( $talkino_chatbox_button_text ); ?><i class="dashicons <?php echo esc_html( get_option( 'talkino_chatbox_icon' ) ); ?> rectangle talkino"></i>
+	</div>
 </label>
 <div class="talkino-chat-wrapper">
 	<div class="talkino-chat-title">
-	<b><?php esc_html_e( 'Offline', 'talkino' ); ?></b>
+		<b><?php esc_html_e( 'Offline', 'talkino' ); ?></b>
+		<label class="talkino-chat-close" for="check">
+			<i class="dashicons dashicons-minus talkino-chat-close-btn"></i>
+		</label> 
 	</div>
 	<div class="talkino-chat-subtitle"> 
 		<span><?php echo esc_html( $talkino_chat_subtitle ); ?></span> 
@@ -71,6 +77,15 @@ if ( is_plugin_active( 'wpml-string-translation/plugin.php' ) ) {
 
 		}
 		?>
-		<input type="button" class="btn btn-primary submit talkino" id="talkino_submit_button" value="<?php esc_html_e( 'Submit', 'talkino' ); ?>">
+		<input type="button" class="talkino-submit-button" id="talkino_submit_button" value="<?php esc_html_e( 'Submit', 'talkino' ); ?>">
 	</form>
+	<?php 
+	if ( get_option( 'talkino_credit' ) === 'on' ) {
+	?>
+	<div class="talkino-footer-wrapper">
+		<a class="talkino-credit-link" href="https://traxconn.com/plugins/talkino/" target=”_blank”>Powered by Talkino</a> 
+	</div>
+	<?php
+	}
+	?>
 </div>

--- a/uninstall.php
+++ b/uninstall.php
@@ -80,12 +80,12 @@ function remove_plugin_data() {
 		delete_option( 'talkino_version' );
 
 		// Settings options.
+		delete_option( 'talkino_chatbox_activation' );
 		delete_option( 'talkino_global_online_status' );
 		delete_option( 'talkino_global_schedule_online_status' );
 		delete_option( 'talkino_chatbox_online_subtitle' );
 		delete_option( 'talkino_chatbox_away_subtitle' );
 		delete_option( 'talkino_chatbox_offline_subtitle' );
-		delete_option( 'talkino_agent_not_available_message' );
 		delete_option( 'talkino_offline_message' );
 		delete_option( 'talkino_chatbox_button_text' );
 		delete_option( 'talkino_chatbox_exclude_pages' );
@@ -94,16 +94,25 @@ function remove_plugin_data() {
 		delete_option( 'talkino_chatbox_style' );
 		delete_option( 'talkino_chatbox_position' );
 		delete_option( 'talkino_chatbox_icon' );
-		delete_option( 'talkino_load_font_awesome_deferred' );
-		delete_option( 'talkino_show_on_desktop' );
-		delete_option( 'talkino_show_on_mobile' );
+		delete_option( 'talkino_chatbox_animation' );
 		delete_option( 'talkino_start_chat_method' );
+		delete_option( 'talkino_chatbox_z_index' );
 		delete_option( 'talkino_chatbox_online_theme_color' );
+		delete_option( 'talkino_chatbox_online_icon_color' );
 		delete_option( 'talkino_chatbox_away_theme_color' );
+		delete_option( 'talkino_chatbox_away_icon_color' );
 		delete_option( 'talkino_chatbox_offline_theme_color' );
+		delete_option( 'talkino_chatbox_offline_icon_color' );
 		delete_option( 'talkino_chatbox_background_color' );
 		delete_option( 'talkino_chatbox_title_color' );
 		delete_option( 'talkino_chatbox_subtitle_color' );
+		delete_option( 'talkino_chatbox_button_color' );
+		delete_option( 'talkino_chatbox_button_text_color' );
+		delete_option( 'talkino_agent_field_background_color' );
+		delete_option( 'talkino_agent_field_hover_background_color' );
+		delete_option( 'talkino_agent_name_text_color' );
+		delete_option( 'talkino_agent_job_title_text_color' );
+		delete_option( 'talkino_agent_channel_text_color' );
 
 		// Ordering options.
 		delete_option( 'talkino_channel_ordering' );
@@ -111,7 +120,11 @@ function remove_plugin_data() {
 		// Display options.
 		delete_option( 'talkino_show_on_post' );
 		delete_option( 'talkino_show_on_search' );
+		delete_option( 'talkino_show_on_404' );
 		delete_option( 'talkino_show_on_woocommerce_pages' );
+		delete_option( 'talkino_show_on_desktop' );
+		delete_option( 'talkino_show_on_mobile' );
+		delete_option( 'talkino_user_visibility' );
 
 		// Contact Form options.
 		delete_option( 'talkino_contact_form_status' );
@@ -125,6 +138,9 @@ function remove_plugin_data() {
 		delete_option( 'talkino_recaptcha_status' );
 		delete_option( 'talkino_recaptcha_site_key' );
 		delete_option( 'talkino_recaptcha_secret_key' );
+
+		// Credit options.
+		delete_option( 'talkino_credit' );
 
 		// Advanced options.
 		delete_option( 'talkino_reset_settings_status' );


### PR DESCRIPTION
- Added: New WordPress official dashicons with search feature for chatbox icon.
- Added: Option to show or hide chatbox on 404 page.
- Added: New animation of chatbox and settings.
- Added: Option to show chatbox only on mobile view for phone.
- Added: New close button at the top of chatbox.
- Added: New design of chatbox.
- Added: New color templates for chatbox.
- Added: New customization of color template.
- Added: New settings of Styles.
- Added: Premium link on plugin page.
- Added: New settings of chatbox z-index field.
- Added: New feature to display or hide credit of Talkino.
- Fixed: Display chatbox under offline mode when all agents are not available or global schedule is offline.
- Fixed: Scrollbar background color on certain versions of web browsers.
- Removed: Font Awesome icon for chatbox to prevent theme conflict in future.
- Removed: The deprecated data of Font Awesome.